### PR TITLE
remove trait from its own opposites

### DIFF
--- a/CK2Plus_expanded/common/traits/000_CK2Plus_expanded_traits.txt
+++ b/CK2Plus_expanded/common/traits/000_CK2Plus_expanded_traits.txt
@@ -65,7 +65,6 @@ machas_javelin  = {
 		eagle_warrior
 		gondi_shahansha
 		kailash_guardian
-		machas_javelin
 		mujahid
 		nyames_shield
 		peruns_chosen


### PR DESCRIPTION
Without this, people with the celtic crusader trait will dislike each other.

This change puts the trait back in line with how the vanilla equivalents work.