### PR TITLE
Fix/duplicate dynasties

### DIFF
--- a/CK2Plus_expanded/common/dynasties/00_dynasties.txt
+++ b/CK2Plus_expanded/common/dynasties/00_dynasties.txt
@@ -47188,7 +47188,7 @@
 	culture = breton
 }
 
-105946 = {
+105948 = {
 	name = "Kernev"
 	culture = breton
 }

--- a/CK2Plus_expanded/common/dynasties/00_dynasties.txt
+++ b/CK2Plus_expanded/common/dynasties/00_dynasties.txt
@@ -39035,7 +39035,7 @@
 }
 
 1048004 = {
-	name = "Ifrinid"
+	name = "Ifranid"
 	culture = maghreb_arabic
 	religion = ibadi
 }
@@ -48913,12 +48913,6 @@
 	name = "Ubayid"
 	culture = bedouin_arabic
 	religion = shiite
-}
-
-1062442 = {
-	name = "Ifranid"
-	culture = maghreb_arabic
-	religion = ibadi
 }
 
 1062443 = {

--- a/CK2Plus_expanded/common/dynasties/00_dynasties.txt
+++ b/CK2Plus_expanded/common/dynasties/00_dynasties.txt
@@ -49907,12 +49907,6 @@
 	religion = catholic
 }
 
-1062595 = {
-	name = "Shahin"
-	culture = levantine_arabic
-	religion = pagan
-}
-
 1062594 = {
 	name = "Khursid"
 	culture = persian

--- a/CK2Plus_expanded/common/dynasties/00_dynasties.txt
+++ b/CK2Plus_expanded/common/dynasties/00_dynasties.txt
@@ -47336,7 +47336,7 @@
 	religion = buddhist
 }
 
-1059971 = {
+1059977 = {
 	name = "Kaukabi"
 	culture = persian
 	religion = shiite

--- a/CK2Plus_expanded/common/dynasties/00_dynasties.txt
+++ b/CK2Plus_expanded/common/dynasties/00_dynasties.txt
@@ -47583,11 +47583,6 @@
 	culture = outremer
 }
 
-1062594 = {
-	name = "Faroaldingi"
-	culture = longobard
-}
-
 1062205 = {
 	name = "af Hvamm"
 	culture = norse
@@ -49825,11 +49820,6 @@
 	name = "Dawlaid"
 	culture = egyptian_arabic
 	religion = sunni
-}
-
-1062594 = {
-	name = "Faroaldingi"
-	culture = lombard
 }
 
 1062595 = {

--- a/CK2Plus_expanded/common/dynasties/00_dynasties.txt
+++ b/CK2Plus_expanded/common/dynasties/00_dynasties.txt
@@ -46870,7 +46870,7 @@
 	religion = west_african_pagan
 }
 
-1000101153 = {
+1060031 = {
 	name = "Gobiri"
 	culture = hausa
 	religion = west_african_pagan

--- a/CK2Plus_expanded/common/dynasties/00_dynasties.txt
+++ b/CK2Plus_expanded/common/dynasties/00_dynasties.txt
@@ -44679,7 +44679,7 @@
 	religion = baltic_pagan
 }
 
-1061019 = {
+1061029 = {
 	name = "von Hanover"
 	culture = german
 	religion = catholic

--- a/CK2Plus_expanded/history/characters/breton.txt
+++ b/CK2Plus_expanded/history/characters/breton.txt
@@ -1,0 +1,5306 @@
+10041 = {
+	name = "Oanez"
+	female = yes
+	dynasty = 311
+	religion = catholic
+	culture = breton
+	trait = gluttonous
+	trait = lustful
+	trait = flamboyant_schemer
+	father = 10042
+	mother = 10043
+	1021.1.1 = {
+		birth = yes
+	}
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+10042 = {
+	name = "Alan"
+	# AKA: Alan 'Caignart'
+	dynasty = 311
+	religion = catholic
+	culture = breton
+	trait = misguided_warrior
+	father = 159678
+	992.1.1 = {
+		birth = yes
+	}
+	1015.1.1 = {
+		add_spouse = 10043
+	}
+	1058.1.1 = {
+		death = yes
+	}
+}
+
+10043 = {
+	name = "Judhael"
+	# AKA: Judith
+	female = yes
+	dynasty = 20016
+	martial = 4
+	diplomacy = 6
+	intrigue = 7
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = charismatic_negotiator
+	father = 10056
+	mother = 1357
+	998.1.1 = {
+		birth = yes
+	}
+	1063.1.1 = {
+		death = yes
+	}
+}
+
+10044 = {
+	name = "Alan"
+	# AKA: Alan
+	dynasty = 22006
+	martial = 8
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = bastard
+	trait = thrifty_clerk
+	father = 348
+	1057.1.2 = {
+		birth = yes
+	}
+	1107.1.2 = {
+		death = yes
+	}
+}
+
+10045 = {
+	name = "Jafrez"
+	# AKA: Goffroi 'Grenonat'
+	dynasty = 22006
+	martial = 6
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 8
+	religion = catholic
+	culture = breton
+	trait = bastard
+	trait = flamboyant_schemer
+	father = 344
+	1025.1.2 = {
+		birth = yes
+	}
+	1084.10.25 = {
+		death = yes
+	}
+}
+
+10047 = {
+	name = "Alan" #Alan Niger
+	# AKA: Alan the Black
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = bastard
+	trait = envious
+	trait = tough_soldier
+	trait = wroth
+	father = 346 #Éon I de Penthièvre
+	#a mistress or mother = 10041
+	1044.1.1 = {
+		birth = yes
+	}
+	1093.1.1 = {
+		death = yes
+	}
+}
+
+10048 = {
+	name = "Derrien" #Lord of the Roche-Derrien
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = temperate
+	trait = tough_soldier
+	trait = bastard
+	father = 346 #Éon I de Penthièvre
+	#a mistress or mother = 10041
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+10051 = {
+	name = "Budic"
+	dynasty = 311
+	religion = catholic
+	culture = breton
+	father = 10042
+	mother = 10043
+	1018.1.1 = {
+		birth = yes
+	}
+	1091.1.1 = {
+		death = yes
+	}
+}
+
+10053 = {
+	name = "Guérech"
+	# AKA: Guerech
+	dynasty = 311
+	religion = catholic
+	culture = breton
+	trait = temperate
+	trait = arbitrary
+	trait = martial_cleric
+	father = 10042
+	mother = 10043
+	1017.1.1 = {
+		birth = yes
+	}
+	1079.1.1 = {
+		death = yes
+	}
+}
+
+10054 = {
+	name = "Bernez"
+	# AKA: Benead
+	dynasty = 311
+	religion = catholic
+	culture = breton
+	trait = lisp
+	trait = just
+	trait = martial_cleric
+	father = 10042
+	mother = 10043
+	1020.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		trait = monk
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+10055 = {
+	name = "Hodierne"
+	female = yes
+	dynasty = 311
+	religion = catholic
+	culture = breton
+	trait = humble
+	trait = martial_cleric
+	father = 10042
+	mother = 10043
+	1019.1.1 = {
+		birth = yes
+	}
+	1049.1.1 = {
+		trait = nun
+	}
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+
+10056 = {
+	name = "Judikael"
+	# AKA: Judikael
+	dynasty = 20016
+	martial = 4
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = tough_soldier
+	father = 50004
+	960.1.1 = {
+		birth = yes
+	}
+	989.1.1 = {
+		add_spouse = 1357
+	}
+	1004.1.1 = {
+		death = yes
+	}
+}
+
+10057 = {
+	name = "Budic"
+	dynasty = 20016
+	martial = 4
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = humble
+	trait = tough_soldier
+	father = 10056
+	mother = 1357
+	990.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		death = yes
+	}
+}
+
+10058 = {
+	name = "Guihomarch"
+	# AKA: Guiomarc'h
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 159679
+	990.1.1 = {
+		birth = yes
+	}
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+10059 = {
+	name = "Morvan"
+	# AKA: Alan or Alan
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91213 #common father with Morvan
+	1030.1.1 = {
+		birth = yes
+	}
+	1085.1.1 = {
+		death = yes
+	}
+}
+
+10060 = {
+	name = "Guimarc'h"
+	# AKA: Guiomarc'h
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91244
+	1056.1.1 = {
+		birth = yes
+	}
+	1103.1.1 = {
+		death = yes
+	}
+}
+
+178 = {
+	name = "Hoël"
+	# AKA: Hoel
+	dynasty = 311
+	martial = 8
+	diplomacy = 8
+	intrigue = 8
+	stewardship = 7
+	religion = catholic
+	culture = breton
+	trait = charismatic_negotiator
+	father = 10042
+	mother = 10043
+	1016.1.1 = {
+		birth = yes
+	}
+	1058.1.1 = {
+		add_spouse = 347
+	}
+	1084.4.13 = {
+		death = yes
+	}
+}
+
+180 = {
+	name = "Alan"
+	# AKA: Alan 'Fergant'
+	dynasty = 311
+	martial = 4
+	diplomacy = 7
+	intrigue = 7
+	stewardship = 4
+	religion = catholic
+	culture = breton
+	father = 178
+	mother = 347
+	1060.1.2 = {
+		birth = yes
+	}
+	1087.1.1 = {
+		add_spouse = 127016
+	}
+	1112.1.8 = {
+		death = yes
+	}
+}
+
+144155 = {
+	name = "Jafrez"
+	dynasty = 312
+	religion = catholic
+	culture = breton
+	father = 40909
+	1067.1.1 = {
+		birth = yes
+	}
+	1142.1.1 = {
+		death = yes
+	}
+}
+
+144156 = {
+	name = "Alan"
+	dynasty = 312
+	religion = catholic
+	culture = breton
+	father = 40909
+	1085.1.1 = {
+		birth = yes
+	}
+	1128.1.1 = {
+		death = yes
+	}
+}
+
+
+205800 = {
+	name = "Magalie"
+	female = yes
+	dynasty = 312
+	martial = 4
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 7
+	religion = catholic
+	culture = breton
+	trait = flamboyant_schemer
+	father = 205802
+	mother = 205750
+	1165.1.10 = {
+		birth = yes
+	}
+	1215.1.10 = {
+		death = yes
+	}
+}
+
+205801 = {
+	name = "Marc'harit"
+	female = yes
+	dynasty = 312
+	martial = 5
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 7
+	religion = catholic
+	culture = breton
+	trait = martial_cleric
+	father = 205802
+	mother = 205750
+	1165.1.10 = {
+		birth = yes
+	}
+	1215.1.10 = {
+		death = yes
+	}
+}
+
+205802 = {
+	name = "Alan"
+	dynasty = 312
+	martial = 6
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = chaste
+	trait = wroth
+	trait = tough_soldier
+	father = 205803
+	mother = 205804
+	1135.1.2 = {
+		birth = yes
+	}
+	1164.1.2 = {
+	add_spouse = 205750
+	}
+	1185.1.2 = {
+		death = yes
+	}
+}
+
+205803 = {
+	name = "Alan"
+	dynasty = 312
+	martial = 7
+	diplomacy = 5
+	intrigue = 4
+	stewardship = 4
+	religion = catholic
+	culture = breton
+	trait = patient
+	trait = proud
+	trait = skilled_tactician
+	father = 144156
+	1110.1.2 = {
+		birth = yes
+	}
+	1168.1.25 = {
+		death = yes
+	}
+}
+
+205804 = {
+	name = "Villana"
+	female = yes
+	dynasty = 313
+	martial = 4
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 7
+	religion = catholic
+	culture = breton
+	trait = scholarly_theologian
+	1105.1.2 = {
+		birth = yes
+	}
+	1169.1.2 = {
+		death = yes
+	}
+}
+
+1355 = {
+	name = "Gisela" # Hypothetical, fantasy name. Married http://en.wikipedia.org/wiki/Hugh_III_of_Maine
+	female = yes
+	dynasty = 22006
+	religion = catholic
+	culture = breton
+	father = 340
+	mother = 379
+	980.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		death = yes
+	}
+}
+
+343 = {
+	name = "Judhael" # http://en.wikipedia.org/wiki/Judith_of_Brittany
+	female = yes
+	dynasty = 22006
+	martial = 4
+	diplomacy = 7
+	intrigue = 8
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = amateurish_plotter
+	father = 340
+	mother = 379
+	982.1.1 = {
+		birth = yes
+	}
+	1017.1.2 = {
+		death = yes
+	}
+}
+
+344 = {
+	name = "Alan"
+	# AKA: Alan
+	dynasty = 22006
+	martial = 5
+	diplomacy = 4
+	intrigue = 8
+	stewardship = 8
+	religion = catholic
+	culture = breton
+	trait = hunchback
+	trait = martial_cleric
+	father = 342
+	mother = 257
+	997.1.1 = {
+		birth = yes
+	}
+	1032.1.1 = {
+		add_spouse = 393
+	}
+	1040.1.15 = {
+		death = yes
+	}
+}
+
+345 = {
+	name = "Adela"
+	female = yes
+	dynasty = 22006
+	martial = 7
+	diplomacy = 4
+	intrigue = 8
+	stewardship = 4
+	religion = catholic
+	culture = breton
+	trait = amateurish_plotter
+	father = 342
+	mother = 257
+	998.1.2 = {
+		birth = yes
+	}
+	1048.1.2 = {
+		death = yes
+	}
+}
+
+346 = {
+	name = "Edouarzh"
+	dynasty = 317
+	religion = catholic
+	culture = breton
+	father = 342
+	mother = 257
+	999.1.1 = {
+		birth = yes
+	}
+	1037.1.1 = {
+		add_spouse = 10041
+	}
+	1079.1.7 = {
+		death = yes
+	}
+}
+
+347 = {
+	name = "Hawiz"
+	female = yes
+	dynasty = 22006
+	martial = 5
+	diplomacy = 6
+	intrigue = 8
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = wroth
+	trait = flamboyant_schemer
+	father = 344
+	mother = 393
+	1033.1.2 = {
+		birth = yes
+	}
+	1072.1.2 = {
+		death = yes
+	}
+}
+
+350 = {
+	name = "Jafrez" #Jafrez I Boterel
+	# AKA: Jafrez 'Boterel'
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 346 #Éon I de Penthièvre
+	mother = 10041 #Oanez de Cornouaille
+	1038.1.1 = {
+		birth = yes
+	}
+	1093.4.24 = {
+		death = yes
+	}
+}
+
+354 = {
+	name = "Briac"
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 346
+	#a mistress
+	1024.1.2 = {
+		birth = yes
+	}
+	1084.1.2 = {
+		death = yes
+	}
+}
+
+356 = {
+	name = "Alan"
+	# AKA: Alan 'Rufus'
+	dynasty = 317
+	religion = catholic
+	culture = breton
+	father = 346
+	mother = 10041
+	1039.1.2 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+50001 = {
+	name = "Mazhe"
+	dynasty = 311
+	martial = 4
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	father = 178
+	mother = 347
+	1064.1.2 = {
+		birth = yes
+	}
+	1103.1.2 = {
+		death = yes
+	}
+}
+
+50002 = {
+	name = "Alan"
+	# AKA: Alan 'Barbetorte'
+	dynasty = 20016
+	martial = 8
+	diplomacy = 6
+	intrigue = 7
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = tough_soldier
+	father = 50007 # Malhuedoc, count of Poher
+	mother = 50006 # Hodierne
+	900.1.1 = {
+		birth = yes
+	}
+	952.1.1 = {
+		death = yes
+	}
+}
+
+50003 = {
+	name = "Drogon"
+	dynasty = 20016
+	martial = 4
+	diplomacy = 6
+	intrigue = 2
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	father = 50002
+	950.1.2 = {
+		birth = yes
+	}
+	958.1.2 = {
+		death = yes
+	}
+}
+
+50004 = {
+	name = "Hoël" # http://en.wikipedia.org/wiki/Ho%C3%ABl_I,_Duke_of_Brittany
+	# AKA: Hoel
+	dynasty = 20016
+	martial = 8
+	diplomacy = 6
+	intrigue = 4
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = bastard
+	trait = tough_soldier
+	father = 50002
+	930.1.1 = {
+		birth = yes
+	}
+	981.1.1 = {
+		death = yes
+	}
+}
+
+50005 = {
+	name = "Guérech"
+	# AKA: Guerech
+	dynasty = 20016
+	martial = 6
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = bastard
+	trait = martial_cleric
+	father = 50002
+	940.1.2 = {
+		birth = yes
+	}
+	990.1.1 = {
+		death = yes
+	}
+}
+
+91159 = {
+	name = "Konan" #Konan III le Gros, duke of Britanny
+	dynasty = 311 #House of Cornouaille
+	religion = catholic
+	culture = breton
+	trait = gluttonous
+	father = 180 #Alan IV de Bretagne
+	mother = 127016 #Ermengarde d'Anjou
+	1095.1.1 = {
+		birth = yes
+	}
+	1110.1.1 = { #before 1113
+		add_spouse = 31399 #Maud Fitzroy, bastard of Harry I Beauclerc
+	}
+	1112.1.1 = {
+		give_nickname = nick_the_fat
+		effect = {
+		set_variable = { which = physique_variable value = 15}
+		}
+		trait = is_fat
+	}
+	1148.9.17 = {
+		death = yes
+	}
+}
+
+91161 = {
+	name = "Jafrez" #Jafrez II de Penthièvre
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205744 #Stefen I de Penthièvre
+	mother = 205745 #Hawiz de Guingamp
+	1090.1.1 = {
+		birth = yes
+	}
+	#Hawise, d. of Jean de Dol
+	1148.1.1 = {
+		death = yes
+	}
+}
+
+91162 = {
+	name = "Rivallon" #Rivallon de Penthièvre
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91161 #Jafrez II de Penthièvre
+	#Hawise, d. of Jean de Dol
+	1130.1.1 = {
+		birth = yes
+	}
+	#Hawise, d. of Jean de Dol
+	1155.1.1 = {
+		death = yes #after 1152
+	}
+}
+
+91163 = {
+	name = "Stefen" #Stefen II de Penthièvre
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91161 #Jafrez II de Penthièvre
+	#Hawise, d. of Jean de Dol
+	1120.1.1 = {
+		birth = yes
+	}
+	1164.1.1 = {
+		death = yes
+	}
+}
+
+91164 = {
+	name = "Jafrez" #Jafrez III de Penthièvre
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91162 #Rivallon de Penthièvre
+	#Hawise, d. of Jean de Dol
+	1150.1.1 = {
+		birth = yes
+	}
+	1209.1.1 = {
+		death = yes
+	}
+}
+
+91165 = {
+	name = "Herri" #Henry II d'Avaugour
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205742 #Alan I de Penthièvre
+	#Pétronille de Beaumont-au-Maine
+	1204.1.5 = {
+		birth = yes
+	}
+	1281.10.6 = {
+		death = yes
+	}
+}
+
+91167 = {
+	name = "Mazhe" #Mathias de Nantes
+	dynasty = 20016 #House of Rennes
+	religion = catholic
+	culture = breton
+	father = 10057 #Budic
+	1008.1.1 = {
+		birth = yes
+	}
+	1050.1.1 = {
+		death = yes
+	}
+}
+
+91168 = {
+	name = "Hoël" #Hoël III de Bretagne
+	dynasty = 311 #House of Cornouaille
+	religion = catholic
+	culture = breton
+	father = 91159 #Konan III le Gros, duke of Britanny
+	mother = 31399 #Maud Fitzroy, bastard of Harry I Beauclerc
+	1113.1.1 = {
+		birth = yes
+	}
+	1148.9.17 = {
+		trait = bastard
+		add_claim = d_brittany
+	}#disinherited by his father
+	1156.1.1 = {
+		death = yes
+	}
+}
+
+91169 = {
+	name = "Alan" #Alan II d'Avaugour
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91165 #Harry II d'Avaugour
+	#Marguerite de Mayenne
+	1224.1.1 = {
+		birth = yes
+	}
+	#Clémence de Beaufort 1246
+	1270.1.1 = {
+		death = yes #after 1268
+	}
+}
+
+205740 = {
+	name = "Konstanza" #Constance, duchess of Brittany
+	female = yes
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = elusive_shadow
+	trait = proud
+	trait = just
+	trait = stubborn
+	trait = gregarious
+	disallow_random_traits = yes
+	father = 205741 #Konan IV le Petit
+	mother = 203510 #Marguerite de Huntinton
+	1161.6.12 = {
+		birth = yes
+	}
+	1201.9.5 = {
+		death = yes
+	}
+}
+
+205741 = {
+	name = "Konan" #Konan IV le Petit
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = dwarf
+	father = 205751 #Alan de Penthièvre
+	mother = 205825 #Berthe de Bretagne
+	1138.1.1 = {
+		birth = yes
+	}
+	1160.1.1 = {
+		add_spouse = 203510 #Marguerite de Huntinton
+	}
+	1171.2.21 = {
+		death = yes
+	}
+}
+
+205744 = {
+	name = "Stefen"
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 346 #Eudes de Penthièvre
+	mother = 10041 #Oanez de Cornouaille
+	1050.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		add_spouse = 205745 #Hawiz de Guingamp
+	}
+	1136.4.13 = {
+		death = yes
+	}
+}
+
+205750 = {
+	name = "Konstanza" #Constance de Bretagne
+	female = yes
+	dynasty = 317 #House of Penthièvre
+	father = 205751 #Alan le Noir
+	mother = 205825 #Berthe de Bretagne
+	religion = catholic
+	culture = breton
+	1140.1.1 = {
+		birth = yes
+	}
+	#spouse of Alan III de Rohan
+	1184.1.19 = {
+		death = yes
+	}
+}
+
+205751 = {
+	name = "Alan" #de Bretagne
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205744 #Stefen I de Penthièvre
+	mother = 205745 #Hawiz de Guingamp
+	1095.1.1 = {
+		birth = yes
+	}
+	1138.1.1 = {
+		add_spouse = 205825 #Bertha de Bretagne
+	}
+	1146.1.1 = {
+		death = yes
+	}
+}
+
+
+40907 = {
+	name = "Guéthenoc"
+	dynasty = 312
+	martial = 7
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 4
+	religion = catholic
+	culture = breton
+	trait = brilliant_strategist
+	father = 91255
+	970.1.2 = {
+		birth = yes
+	}
+	1022.1.2 = {
+		death = yes
+	}
+}
+
+40908 = {
+	name = "Iocilin"
+	dynasty = 312
+	martial = 5
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 5
+	religion = catholic
+	culture = breton
+	trait = envious
+	trait = just
+	trait = charismatic_negotiator
+	father = 40907
+	1010.1.2 = {
+		birth = yes
+	}
+	1074.1.2 = {
+		death = yes
+	}
+}
+
+40909 = {
+	name = "Eozen"
+	dynasty = 312
+	martial = 6
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = gluttonous
+	trait = proud
+	trait = flamboyant_schemer
+	father = 40908
+	1045.1.2 = {
+		birth = yes
+	}
+	1095.1.2 = {
+		death = yes
+	}
+}
+
+40910 = {
+	name = "Menguy"
+	dynasty = 312
+	martial = 5
+	diplomacy = 5
+	intrigue = 6
+	stewardship = 5
+	religion = catholic
+	culture = breton
+	trait = gluttonous
+	trait = slothful
+	trait = detached_priest
+	father = 40908
+	1047.1.2 = {
+		birth = yes
+	}
+	1097.1.2 = {
+		death = yes
+	}
+}
+
+455580 = {
+	name = "Janed" #Jeanne d'Avaugour
+	female = yes
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91258 #Harry IV d'Avaugour
+	#Jeanne d'Harcourt
+	1290.1.1 = {
+		birth = yes
+	}
+	#Guy de Bretagne, compte de Penthièvre (1318)
+	1327.8.30 = {
+		death = yes
+	}
+}
+
+455581 = {
+	name = "Herri" #I assume he is Henry III d'Avaugour
+	dynasty = 317 #House of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91169 #Alan II d'Avaugour
+	#Clémence de Beaufort, lady of Dinan
+	1247.1.1 = {
+		birth = yes
+	}
+	#Marie de Brienne in 1270
+	1301.1.1 = {
+		death = yes
+	}
+}
+
+205825 = {
+	name = "Berthildis" #Bertha, duchess of Britanny
+	female = yes
+	dynasty = 311 #House of Cornouaille
+	martial = 5
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 8
+	learning = 5
+	religion = catholic
+	culture = breton
+	trait = patient
+	trait = brave
+	trait = thrifty_clerk
+	father = 91159 #Konan III le Gros, duke of Britanny
+	mother = 31399 #Maude d'Angleterre
+	1114.1.1 = {
+		birth = yes
+	}
+	#Alan de Penthièvre (1138.1.1)
+	1157.1.17 = {
+		death = yes
+	}
+}
+
+5650 = {
+	name = "Ralf"
+	# AKA: Radulf 'Stalre'
+	dynasty = 559
+	martial = 4
+	diplomacy = 8
+	intrigue = 8
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = craven
+	trait = tough_soldier
+	1011.1.1 = {
+		birth = yes
+	}
+	1068.1.1 = {
+		death = yes
+	}
+}
+
+5652 = {
+	name = "Ralf"
+	# AKA Radulf 'de Guader'
+	dynasty = 559
+	martial = 5
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 6
+	religion = catholic
+	culture = breton
+	trait = deceitful
+	trait = just
+	trait = skilled_tactician
+	father = 5650
+	1040.1.2 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		employer = 140
+	}
+	1096.1.2 = {
+		death = yes
+	}
+}
+
+91213 = {
+	name = "Hamon"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 159679
+	988.1.1 = {
+		birth = yes
+	}
+	1041.1.1 = {
+		death = yes
+	}
+}
+
+91215 = {
+	name = "Huiarnviu" #Huiarnviu II
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 10060 #Guimarc'h II
+	1080.1.1 = {
+		birth = yes
+	}
+	1168.1.1 = {
+		death = yes
+	}
+}
+
+91216 = {
+	name = "Hamon" #Hamon
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91215 #Huiarnviu II
+	1131.1.1 = {
+		birth = yes
+	}
+	1171.1.25 = {
+		death = yes
+	}
+}
+
+91217 = {
+	name = "Huiarnviu" #Huiarnviu
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 10060 #Guimarc'h II
+	1085.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes #after 1128.3.3
+	}
+}
+
+91218 = {
+	name = "Guimarc'h" #Guimarc'h de Léon
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205787 #Huiarnviu
+	1200.1.1 = {
+		birth = yes
+	}
+	1235.1.1 = {
+		death = yes #after 1231.5.1
+	}
+}
+
+91219 = {
+	name = "Huiarnviu" #Huiarnviu III de Léon
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91218 #Guimarc'h de Léon
+	1220.1.1 = {
+		birth = yes
+	}
+	#Marguerite
+	1265.1.1 = {
+		death = yes
+	}
+}
+
+91220 = {
+	name = "Huiarnviu" #Huiarnviu IV de Léon
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91219 #Huiarnviu III de Léon
+	#Marguerite
+	1240.1.1 = {
+		birth = yes
+	}
+	1300.1.1 = {
+		death = yes #after 1254.6.7
+	}
+}
+
+91221 = {
+	name = "Ame" #Ame de Léon
+	dynasty = 20017 #La Marck
+	female = yes
+	religion = catholic
+	culture = breton
+	father = 91220 #Huiarnviu IV de Léon
+	1260.1.1 = {
+		birth = yes
+	}
+	#Prigent de Coëtmen, viscount of Tonquedec
+	1300.1.1 = {
+		death = yes #after 1254.6.7
+	}
+}
+
+91222 = {
+	name = "Ame" #Ame de Léon
+	dynasty = 20017 #La Marck
+	female = yes
+	religion = catholic
+	culture = breton
+	father = 91219 #Huiarnviu III de Léon
+	#Marguerite
+	1260.1.1 = {
+		birth = yes
+	}
+	#Roland de Dinan
+	1280.1.1 = {
+		death = yes #after 1276.10.1
+	}
+}
+
+91223 = {
+	name = "Huiarnviu" #Huiarnviu de Léon
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91220 #Huiarnviu IV de Léon
+	1265.1.1 = {
+		birth = yes
+	}
+	1325.1.1 = {
+		death = yes #after 1224.1.1
+	}
+}
+
+91224 = {
+	name = "Huiarnviu" #Huiarnviu de Léon
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91223 #Huiarnviu IV de Léon
+	1285.1.1 = {
+		birth = yes
+	}
+	#Marguerite, d. of Gerard Chabot, lord of Rays & of Machecoul
+	1365.1.1 = {
+		death = yes
+	}
+}
+
+91214 = {
+	name = "Edouarzh" #Ehuarn
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 10059 #Morvan, viscount of LÈon
+	1050.1.1 = {
+		birth = yes
+	}
+	1085.1.1 = {
+		death = yes
+	}
+}
+
+91245 = {
+	name = "Alfred"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 10058 #Guimarc'h I
+	1015.1.1 = {
+		birth = yes
+	}
+	1095.1.1 = {
+		death = yes
+	}
+}
+
+91246 = {
+	name = "Iudicael" #
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 159696
+	860.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+91247 = {
+	name = "Berenger" #Berenger, count of Bayeux and of Rennes
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 91246 #his father, called ingame Judikael
+	889.1.1 = {
+		birth = yes
+	}
+	#spouse the daughter of Gurvand of Britanny
+	930.1.1 = {
+		death = yes #before 931
+	}
+}
+
+91248 = {
+	name = "Judikael" #Judikael/Juhael
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 91247 #Berenger
+	#d. of Gurvand of Britanny
+	903.1.1 = {
+		birth = yes
+	}
+	958.1.1 = {
+		death = yes
+	}
+}
+
+91249 = {
+	name = "Meen"
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 91248 #Judikael
+	925.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		death = yes
+	}
+}
+
+91250 = {
+	name = "Enoguen"
+	female = yes
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 91248 #Judikael
+	929.1.1 = {
+		birth = yes
+	}
+	#Triscan de Vitré
+	1000.1.1 = {
+		death = yes
+	}
+}
+
+91251 = {
+	name = "Judikael"
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 340 #Konan le Tort
+	mother = 379 #Ermengarde d'Anjou
+	985.1.1 = {
+		birth = yes
+	}
+	1037.1.1 = {
+		death = yes
+	}
+}
+
+91252 = {
+	name = "Catuallon"
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 340 #Konan le Tort
+	mother = 379 #Ermengarde d'Anjou
+	986.1.1 = {
+		birth = yes
+	}
+	1050.1.15 = {
+		death = yes #this day or after
+	}
+}
+
+91253 = {
+	name = "Urvod" #Hurnod/Urvod de Bretagne
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 340 #Konan le Tort
+	mother = 379 #Ermengarde d'Anjou
+	987.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes #after 1026
+	}
+}
+
+91254 = {
+	name = "Alan"
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 340 #Konan le Tort
+	990.1.1 = {
+		birth = yes
+	}
+	1070.1.1 = {
+		death = yes
+	}
+}
+
+91255 = {
+	name = "Iudicael" #aka Glanderius
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 340 #Conan le Tort
+	951.1.1 = {
+		birth = yes
+	}
+	1000.1.1 = {
+		death = yes
+	}
+}
+
+91256 = {
+	name = "Alan"
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 340 #Konan le Tort
+	991.1.1 = {
+		birth = yes
+	}
+	1065.1.1 = {
+		death = yes
+	}
+}
+
+91257 = {
+	name = "Konan"
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 340 #Konan le Tort
+	992.1.1 = {
+		birth = yes
+	}
+	1070.1.1 = {
+		death = yes
+	}
+}
+
+91260 = {
+	name = "Evenus" #Evenus/Linzoël de Bretagne
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 342 #Jafrez I de Bretagne
+	mother = 257 #Havise de Normandie
+	998.1.1 = {
+		birth = yes
+	}
+	1040.1.1 = {
+		death = yes #after 1037
+	}
+}
+
+91261 = {
+	name = "Gwilherm" #Guillaume de Bretagne
+	dynasty = 317#Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 346 #Eudes de Bretagne
+	mother = 10041 #Oanez de Cornouaille
+	1040.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+91262 = {
+	name = "Roparzh" #Robert de Bretagne
+	dynasty = 317#Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 346 #Eudes de Bretagne
+	mother = 10041 #Oanez de Cornouaille
+	1041.1.1 = {
+		birth = yes
+	}
+	1085.1.1 = {
+		death = yes #after 1083
+	}
+}
+
+91263 = {
+	name = "Richard" #Richard de Bretagne
+	dynasty = 317#Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 346 #Eudes de Bretagne
+	mother = 10041 #Oanez de Cornouaille
+	1042.1.1 = {
+		birth = yes
+	}
+	1105.1.1 = {
+		death = yes
+	}
+}
+
+91264 = {
+	name = "Bodin"
+	dynasty = 317#Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 346 #Eudes de Bretagne
+	1040.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+91265 = {
+	name = "Ribald"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 346 #Eudes de Bretagne
+	1041.1.1 = {
+		birth = yes
+	}
+	1101.1.1 = {
+		death = yes
+	}
+}
+
+91266 = {
+	name = "Bardulf"
+	dynasty = 317 #Rennes house of Penthièvre-Ravensworth
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 346 #Eudes de Bretagne
+	1042.1.1 = {
+		birth = yes
+	}
+	1102.1.1 = {
+		death = yes
+	}
+}
+
+91267 = {
+	name = "Arnald"
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 346 #Eudes de Bretagne
+	1043.1.1 = {
+		birth = yes
+	}
+	1103.1.1 = {
+		death = yes
+	}
+}
+
+91268 = {
+	name = "Elina" #bastard daughter
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 346 #Eudes de Bretagne
+	1044.1.1 = {
+		birth = yes
+	}
+	1104.1.1 = {
+		death = yes
+	}
+}
+
+91269 = {
+	name = "Konan"
+	dynasty = 317#Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 350 #Jafrez Boretel
+	#unknow mother
+	1054.1.1 = {
+		birth = yes
+	}
+	1098.2.9 = {
+		death = yes
+	}
+}
+
+91270 = {
+	name = "Acarias"
+	dynasty = 317 #Rennes house of Penthièvre-Ravensworth
+	religion = catholic
+	culture = breton
+	father = 91266 #Bardulf
+	1065.1.1 = {
+		birth = yes
+	}
+	1140.1.1 = {
+		death = yes #after 1130
+	}
+}
+
+91271 = {
+	name = "Scolland"
+	dynasty = 317 #Rennes house of Penthièvre-Ravensworth
+	religion = catholic
+	culture = breton
+	father = 91266 #Bardulf
+	1070.1.1 = {
+		birth = yes
+	}
+	1145.1.1 = {
+		death = yes #after 1130
+	}
+}
+
+91272 = {
+	name = "Huiarnviuy"
+	dynasty = 317 #Rennes house of Penthièvre-Ravensworth
+	religion = catholic
+	culture = breton
+	father = 91270 #Acarias
+	1090.1.1 = {
+		birth = yes
+	}
+	1150.1.1 = {
+		death = yes
+	}
+}
+
+91273 = {
+	name = "Walter"
+	dynasty = 317 #Rennes house of Penthièvre-Ravensworth
+	religion = catholic
+	culture = breton
+	father = 91270 #Acarias
+	1092.1.1 = {
+		birth = yes
+	}
+	1152.1.1 = {
+		death = yes
+	}
+}
+
+91274 = {
+	name = "Harscoit"
+	dynasty = 317 #Rennes house of Penthièvre-Ravensworth
+	religion = catholic
+	culture = breton
+	father = 91270 #Acarias
+	1095.1.1 = {
+		birth = yes
+	}
+	1155.1.1 = {
+		death = yes
+	}
+}
+
+91275 = {
+	name = "Herri"
+	dynasty = 317 #Rennes house of Penthièvre-Ravensworth
+	religion = catholic
+	culture = breton
+	father = 91270 #Acarias
+	1096.1.1 = {
+		birth = yes
+	}
+	1156.1.1 = {
+		death = yes
+	}
+}
+
+91276 = {
+	name = "Mathilde" #Mathilde de Penthièvre
+	female = yes
+	dynasty = 317#Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205744 #Stefen de Bretagne
+	mother = 205745 #Havise de Gingamp
+	1102.1.1 = {
+		birth = yes
+	}
+	1170.1.1 = {
+		death = yes
+	}
+}
+
+91277 = {
+	name = "Tiphaine" #Tiphaine de Penthièvre
+	female = yes
+	dynasty = 317#Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205744 #Stefen de Bretagne
+	mother = 205745 #Havise de Gingamp
+	1112.1.1 = {
+		birth = yes
+	}
+	1175.1.1 = {
+		death = yes
+	}
+}
+
+91278 = {
+	name = "Gonnor" #Gonnor de Penthièvre
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205744 #Stefen de Bretagne
+	mother = 205745 #Havise de Gingamp
+	1113.1.1 = {
+		birth = yes
+	}
+	1175.1.1 = {
+		death = yes
+	}
+}
+
+91279 = {
+	name = "Olive"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205744 #Stefen de Bretagne
+	mother = 205745 #Havise de Gingamp
+	1113.1.1 = {
+		birth = yes
+	}
+	1175.1.1 = {
+		death = yes
+	}
+}
+
+91280 = {
+	name = "Stefen" #Stefen de Penthièvre
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91162 #Rivallon de Penthièvre
+	#? de Dol
+	1145.1.1 = {
+		birth = yes
+	}
+	1164.1.1 = {
+		death = yes
+	}
+}
+
+91281 = {
+	name = "Elina" #Elina de Penthièvre
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91162 #Rivallon de Penthièvre
+	#? de Dol
+	1155.1.1 = {
+		birth = yes
+	}
+	1215.1.1 = {
+		death = yes
+	}
+}
+
+91282 = {
+	name = "Enoguen" #Enoguen de Penthièvre
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205751 #Alan le Noir
+	mother = 205825 #Berthe de Bretagne
+	1145.1.1 = {
+		birth = yes
+	}
+	1187.1.1 = {
+		death = yes
+	}
+}
+
+91283 = {
+	name = "Roparzh" #Robert Brito
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = bastard
+	father = 205751 #Alan le Noir
+	1145.1.1 = {
+		birth = yes
+	}
+	1187.1.1 = {
+		death = yes
+	}
+}
+
+91284 = {
+	name = "Herri" #Harry de Penthièvre
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205743 #Harry de Bretagne
+	mother = 205760 #Mathilde de Vendôme
+	1152.1.1 = {
+		birth = yes
+	}
+	1152.12.1 = {
+		death = yes
+	}
+}
+
+91285 = {
+	name = "Stefen" #Stefen de Penthièvre
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205743 #Harry de Bretagne
+	mother = 205760 #Mathilde de Vendôme
+	1155.1.1 = {
+		birth = yes
+	}
+	1205.1.1 = {
+		death = yes #after 1202
+	}
+}
+
+91286 = {
+	name = "Juhaël"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91165 #Harry
+	#Marguerite de Mayenne
+	1235.1.1 = {
+		birth = yes
+	}
+	1295.1.1 = {
+		death = yes
+	}
+}
+
+91287 = {
+	name = "Herri" #lord of Goello
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91165 #Harry
+	#Marguerite de Mayenne
+	1240.1.1 = {
+		birth = yes
+	}
+	#Phelipe de Rohan, d. of Alan V, vicompte de Rohan
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+91288 = {
+	name = "Mari" #Marie de Penthièvre
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91165 #Harry
+	#Marguerite de Mayenne
+	1245.1.1 = {
+		birth = yes
+	}
+	1305.1.1 = {
+		death = yes
+	}
+}
+
+91289 = {
+	name = "Janed" #Jeanne d'Avalgor
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91165 #Harry
+	#Marguerite de Mayenne
+	1250.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+91290 = {
+	name = "Jafrez" #Jafrez Borotel
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205742 #Alan, comte de Penthièvre
+	#Adélaïde
+	1210.1.1 = {
+		birth = yes
+	}
+	#Eustachie de Vitré, d. of André III de Vitré & Catherine de Thouars
+	1281.1.1 = {
+		death = yes
+	}
+}
+
+91291 = {
+	name = "Hawiz" #Haoys d'Avaugour
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91169 #Alan d'Avaugour
+	#Clémence de Dinan
+	1250.1.1 = {
+		birth = yes
+	}
+	#Olivier de Tinteniac
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+91292 = {
+	name = "Konstanza"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91169 #Alan d'Avaugour
+	#Clémence de Dinan
+	1255.1.1 = {
+		birth = yes
+	}
+	1315.10.29 = {
+		death = yes
+	}
+}
+
+91293 = {
+	name = "Yann" #Jean, bishop of Saint-Brieue
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	trait = detached_priest
+	father = 455581 #Harry III d'Avaugour
+	#Marie de Beaumont-Brienne, d. of Louis of Brienne & Oanez of Beaumont.
+	1275.1.1 = {
+		birth = yes
+	}
+	1329.1.1 = {
+		death = yes
+	}
+}
+
+91294 = {
+	name = "Gwilherm"
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 455581 #Harry III d'Avaugour
+	#Marie de Beaumont-Brienne, d. of Louis of Brienne & Oanez of Beaumont.
+	1276.1.1 = {
+		birth = yes
+	}
+	1290.1.1 = {
+		death = yes
+	}
+}
+
+91295 = {
+	name = "Blanche" #Blanche d'Avaugour
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 455581 #Harry III d'Avaugour
+	#Marie de Beaumont-Brienne, d. of Louis of Brienne & Oanez of Beaumont.
+	1277.1.1 = {
+		birth = yes
+	}
+	#Guillaume d'Harcourt, lord of Saussaye
+	1340.12.10 = {
+		death = yes #a 10th of december, after 1337
+	}
+}
+
+91296 = {
+	name = "Marc'harit" #Marguerite d'Avaugour
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 455581 #Harry III d'Avaugour
+	#Marie de Beaumont-Brienne, d. of Louis of Brienne & Oanez of Beaumont.
+	1278.1.1 = {
+		birth = yes
+	}
+	#Guillaume de Paynel, lord of Hambie (1296)
+	1340.1.1 = {
+		death = yes
+	}
+}
+
+91258 = {
+	name = "Herri" #Harry IV d'Avaugour
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 455581 #Harry III d'Avaugour
+	#Marie de Beaumont-Brienne, d. of louis de Brienne & Oanez de Beaumont.
+	1274.1.1 = {
+		birth = yes
+	}
+	#Jeanne d'Harcourt, d. of Jean II d'Harcourt & Jeanne of Châtellerault
+	1331.1.1 = {
+		death = yes
+	}
+}
+
+91297 = {
+	name = "Isabelle"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91258 #Harry IV d'Avaugour
+	#Marie de Beaumont-Brienne, d. of louis de Brienne & Oanez de Beaumont.
+	1294.1.1 = {
+		birth = yes
+	}
+	#Louis, viscount of Thouars (455930)
+	1330.5.3 = {
+		death = yes
+	}
+}
+
+91298 = {
+	name = "Marc'harit"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91258 #Harry IV d'Avaugour
+	1295.1.1 = {
+		birth = yes
+	}
+	#Huiarnviu VII de Léon
+	#Jafrez de Vaulx
+	1340.1.1 = {
+		death = yes
+	}
+}
+
+91299 = {
+	name = "Mari"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91258 #Harry IV d'Avaugour
+	1296.1.1 = {
+		birth = yes
+	}
+	1345.4.11 = {
+		death = yes
+	}
+}
+
+91300 = {
+	name = "Alan" #Alan, vicomte de Tonquedec
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205747 #Geslin de Penthièvre
+	1175.1.1 = {
+		birth = yes
+	}
+	1255.1.1 = {
+		death = yes #after 1253
+	}
+}
+
+91301 = {
+	name = "Herri"
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205747 #Geslin de Penthièvre
+	1180.1.1 = {
+		birth = yes
+	}
+	1233.1.1 = {
+		death = yes
+	}
+}
+
+91302 = {
+	name = "Hoël"
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 205747 #Geslin de Penthièvre
+	1185.1.1 = {
+		birth = yes
+	}
+	1240.1.1 = {
+		death = yes #after 1239
+	}
+}
+
+91303 = {
+	name = "Roland" #Roland de Tonquedec
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91300 #Alan, viscount of Tonquedec
+	#Constance de Vitré
+	1195.1.1 = {
+		birth = yes
+	}
+	1295.1.1 = {
+		death = yes #before 1300
+	}
+}
+
+91304 = {
+	name = "Prigent" #Prigent de Coëtmen
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91303 #Roland de Tonquedec
+	1220.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes #after 1300
+	}
+}
+
+
+91306 = {
+	name = "Guy"
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91304 #Prigent de Coëtmen
+	1240.1.1 = {
+		birth = yes
+	}
+	1330.1.1 = {
+		death = yes
+	}
+}
+
+91307 = {
+	name = "Janed"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre
+	religion = catholic
+	culture = breton
+	father = 91306 #Guy
+	1260.1.1 = {
+		birth = yes
+	}
+	1320.1.1 = {
+		death = yes
+	}
+}
+
+91309 = {
+	name = "Ralph"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91265 #Ribald
+	1060.1.1 = {
+		birth = yes
+	}
+	1120.1.1 = {
+		death = yes
+	}
+}
+
+91310 = {
+	name = "Huiarnviu" #Huiarnviu Taillebois
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91265 #Ribald
+	1062.1.1 = {
+		birth = yes
+	}
+	1122.1.1 = {
+		death = yes
+	}
+}
+
+91311 = {
+	name = "Raynaud" #Raynaud Taillebois
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91265 #Ribald
+	1065.1.1 = {
+		birth = yes
+	}
+	1125.1.1 = {
+		death = yes
+	}
+}
+
+91312 = {
+	name = "Gwilherm" #William Taillebois
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91265 #Ribald
+	1066.1.1 = {
+		birth = yes
+	}
+	1126.1.1 = {
+		death = yes
+	}
+}
+
+91313 = {
+	name = "Roparzh"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91309 #Ralph
+	1080.1.1 = {
+		birth = yes
+	}
+	1170.1.1 = {
+		death = yes
+	}
+}
+
+91314 = {
+	name = "Walran"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91313 #Robert
+	1150.1.1 = {
+		birth = yes
+	}
+	1240.1.1 = {
+		death = yes
+	}
+}
+
+91315 = {
+	name = "Ralph"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91313 #Robert
+	1155.1.1 = {
+		birth = yes
+	}
+	1250.1.1 = {
+		death = yes
+	}
+}
+
+91316 = {
+	name = "Randulf"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91313 #Robert
+	1160.1.1 = {
+		birth = yes
+	}
+	1251.1.1 = {
+		death = yes
+	}
+}
+
+91317 = {
+	name = "Ralph"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91316 #Randulf
+	1200.1.1 = {
+		birth = yes
+	}
+	1258.3.31 = {
+		death = yes
+	}
+}
+
+91318 = {
+	name = "Berthildis"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91316 #Randulf
+	1205.1.1 = {
+		birth = yes
+	}
+	1265.1.1 = {
+		death = yes
+	}
+}
+
+91319 = {
+	name = "Randulf"
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91316 #Randulf
+	1210.1.1 = {
+		birth = yes
+	}
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+91320 = {
+	name = "Mari"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91317 #Ralph
+	1240.1.1 = {
+		birth = yes
+	}
+	1320.1.1 = {
+		death = yes
+	}
+}
+
+91321 = {
+	name = "Janed"
+	female = yes
+	dynasty = 317 #Rennes house of Penthièvre-Middleham
+	religion = catholic
+	culture = breton
+	father = 91317 #Ralph
+	1245.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes #before the 1st of april, 1310
+	}
+}
+
+205780 = {
+	name = "Guimarc'h"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 91215 #Huiarnviu II
+	1130.1.1 = {
+		birth = yes
+	}
+	1167.1.1 = {
+		add_spouse = 205746
+	}
+	1179.1.9 = {
+		death = yes
+	}
+}
+
+
+205781 = {
+	name = "Guimarc'h"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205780 #Guimarc'h III
+	#mother = 205746 #Nobilis
+	1167.1.1 = {
+		birth = yes
+	}
+	1183.1.10 = {
+		add_spouse = 205800 #Marguilia
+	}
+	1218.3.14 = {
+		death = yes
+	}
+}
+
+205782 = {
+	name = "Huiarnviu"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205780 #Guimarc'h III
+	#mother = 205746 #Nobilis
+	1168.1.1 = {
+		birth = yes
+	}
+	1180.1.1 = {
+		add_spouse = 205801
+	}
+	1218.1.1 = {
+		death = yes
+	}
+}
+
+205783 = {
+	name = "Azenor"
+	#AKA Eléonore or Léonore (?)
+	female = yes
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205780 #Guimarc'h III
+	#mother = 205746 #Nobilis
+	1145.1.1 = {
+		birth = yes
+	}
+	1216.1.1 = {
+	death = yes
+	}
+}
+
+205784 = { #who is he?
+	name = "Adam"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205780
+	mother = 205746
+	1170.1.1 = {
+		birth = yes
+	}
+	1217.1.1 = {
+		death = yes
+	}
+}
+
+205785 = { #who is she?
+	name = "Ennougen"
+	female = yes
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205780
+	#mother = 205746
+	1168.1.1 = {
+		birth = yes
+	}
+	1218.1.1 = {
+		death = yes
+	}
+}
+
+#205786 = { #who is she?
+#	name = "Berthe"
+#	female = yes
+#	dynasty = 20017 #La Marck
+#	religion = catholic
+#	culture = breton
+#	father = 205780
+#	mother = 205746
+#	1187.1.1 = {
+#		birth = yes
+#	}
+#	1229.1.1 = {
+#		death = yes
+#	}
+#}
+
+205787 = {
+	name = "Huiarnviu"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205781
+	mother = 205800
+	1184.1.1 = {
+		birth = yes
+	}
+	1218.1.1 = {
+		death = yes
+	}
+}
+
+205788 = {
+	name = "Azenor"
+	female = yes
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205782
+	mother = 205801
+	1187.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+205789 = {
+	name = "Huiarnviu"
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205782
+	mother = 205801
+	1183.1.1 = {
+		birth = yes
+	}
+	1233.1.1 = {
+		death = yes
+	}
+}
+
+205790 = {
+	name = "Konstanza"
+	female = yes
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205782
+	mother = 205801
+	1185.1.1 = {
+		birth = yes
+	}
+	1235.1.1 = {
+		death = yes
+	}
+}
+
+205791 = {
+	name = "Emma"
+	female = yes
+	dynasty = 20017 #La Marck
+	religion = catholic
+	culture = breton
+	father = 205830
+	mother = 205785
+	1184.1.1 = {
+		birth = yes
+	}
+	1234.1.1 = {
+		death = yes
+	}
+}
+
+340 = {
+	name = "Conan" #Conan I le Tort
+	# AKA: Conan
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 91248 #Iudicael
+	#Gerberge, d. of.
+	935.1.1 = {
+		birth = yes
+	}
+	973.1.1 = {
+		add_spouse = 379
+	}
+	992.6.27 = {
+		death = {
+			death_reason = death_battle
+			killer = 374 #Foulque III Nerra, Count of Anjou
+		}
+	}
+}
+
+342 = {
+	name = "Jafrez"
+	# AKA: Goffroy
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 340
+	mother = 379
+	977.1.1 = {
+		birth = yes
+	}
+	996.1.1 = {
+		add_spouse = 257
+	}
+	1020.1.1 = {
+		death = yes
+	}
+}
+
+348 = {
+	name = "Konan"
+	# AKA: Konan
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	trait = flamboyant_schemer
+	trait = strong
+	trait = cynical
+	trait = paranoid
+	trait = ambitious
+	disallow_random_traits = yes
+
+	father = 344
+	mother = 393
+	1033.1.1 = {
+		birth = yes
+	}
+	1066.1.5 = {
+		add_claim = d_normandy
+	}
+	1066.12.11 = {
+		death = yes
+	}
+}
+
+50006 = {
+	name = "Hodierne"
+	female = yes
+	dynasty = 20137 #Vannes
+	religion = catholic
+	culture = breton
+	father = 50008 # Alan I, the Great
+
+	879.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+50007 = {
+	name = "Malhuedoc"
+	dynasty = 20016 #Nantes
+	religion = catholic
+	culture = breton
+	father = 50009
+	870.1.1 = {
+		birth = yes
+	}
+	895.1.1 = {
+		add_spouse = 50006
+	}
+	931.1.1 = {
+		death = yes
+	}
+}
+
+50008 = {
+	name = "Alan"
+	dynasty = 20137 #Vannes
+	religion = catholic
+	culture = breton
+	father = 50010
+	855.1.1 = {
+		birth = yes
+	}
+	877.1.1 = {
+		give_nickname = nick_the_great
+	}
+	907.1.1 = {
+		death = yes
+	}
+}
+
+50009 = {
+	name = "Pascueten"
+	dynasty = 20137 #Vannes
+	religion = catholic
+	culture = breton
+	father = 50010
+	850.1.1 = {
+		birth = yes
+	}
+	877.1.1 = {
+		death = yes
+	}
+}
+
+50010 = {
+	name = "Ridoredh"
+	dynasty = 20137 #Vannes
+	religion = catholic
+	culture = breton
+
+	father = 159695
+	832.1.1 = {
+		birth = yes
+	}
+	877.1.1 = {
+		death = yes
+	}
+}
+
+50011 = {
+	name = "Pasquitan"
+	dynasty = 20137 #Vannes
+	religion = catholic
+	culture = breton
+	father = 50008
+	881.1.1 = {
+		birth = yes
+	}
+	903.1.1 = {
+		death = yes
+	}
+}
+
+203041 = {
+	name = "Alan"
+	dynasty = 3134
+	religion = catholic
+	culture = breton
+	father = 180049
+	martial = 5
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 7
+	trait = tough_soldier
+	1070.1.1 = {
+		birth = yes
+	}
+	1102.1.1 = {
+		add_spouse = 180782
+	}
+	1114.1.1 = {
+		death = yes
+	}
+}
+
+161281 = {
+	name = "Cadoc"
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161282
+
+	1031.1.1 = {
+		birth = yes
+	}
+	1057.1.1 = {
+		add_spouse = 161283
+	}
+	1081.1.1 = {
+		death = yes
+	}
+}
+
+
+161282 = {
+	name = "Cador"
+	dynasty = 1029042 #
+	religion = catholic
+	culture = breton
+	father = 159741
+
+	1010.1.1 = {
+		birth = yes
+	}
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+
+
+161283 = {
+	name = "Marguarite"
+	female = yes
+	dynasty = 0
+	religion = catholic
+	culture = breton
+
+	1041.1.1 = {
+		birth = yes
+	}
+	1091.1.1 = {
+		death = yes
+	}
+}
+
+
+
+161284 = {
+	name = "Rioantdrec"
+	female = yes
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161281
+	mother = 161283
+	1058.1.1 = {
+		birth = yes
+	}
+
+	1108.1.1 = {
+		death = yes
+	}
+}
+
+
+
+
+161285 = {
+	name = "Enoguen"
+	female = yes
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161281
+	mother = 161283
+	1059.1.1 = {
+		birth = yes
+	}
+
+	1109.1.1 = {
+		death = yes
+	}
+}
+
+161286 = {
+	name = "Dumnarth"
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161282
+
+	1034.1.1 = {
+		birth = yes
+	}
+	1056.1.1 = {
+		add_spouse = 161287
+	}
+	1084.1.1 = {
+		death = yes
+	}
+}
+
+161287 = {
+	name = "Tanetbiu"
+	dynasty = 0
+	female = yes
+	religion = catholic
+	culture = breton
+
+	1040.1.1 = {
+		birth = yes
+	}
+	1095.1.1 = {
+		death = yes
+	}
+}
+
+161288 = {
+	name = "Conan"
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161286
+	mother = 161287
+	1062.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+161289 = {
+	name = "Alan"
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161286
+	mother = 161287
+	1063.1.1 = {
+		birth = yes
+	}
+
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+161290 = {
+	name = "Hoël"
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161286
+	mother = 161287
+	1064.1.1 = {
+		birth = yes
+	}
+
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+161291 = {
+	name = "Janed"
+	female = yes
+	dynasty = 1029042
+	religion = catholic
+	culture = breton
+	father = 161286
+	mother = 161287
+	1060.1.1 = {
+		birth = yes
+	}
+
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+161427 = {
+	name = "Harduin"
+	dynasty = 559
+	religion = catholic
+	culture = breton
+	father = 5650
+	1042.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		employer = 140
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+161428 = {
+	name = "Gwilherm"
+	dynasty = 559
+	religion = catholic
+	culture = breton
+	father = 5652
+	1070.1.1 = {
+		birth = yes
+	}
+
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+161429 = {
+	name = "Riwal"
+	dynasty = 559
+	religion = catholic
+	culture = breton
+	father = 5652
+	1072.1.1 = {
+		birth = yes
+	}
+	1125.1.1 = {
+		death = yes
+	}
+}
+
+161430 = {
+	name = "Alan"
+	dynasty = 559
+	religion = catholic
+	culture = breton
+	father = 5652
+	1074.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+163105 = {
+	name = Salomon
+	dynasty = 1029102 #de Poher
+	religion = catholic
+	diplomacy = 7
+	martial = 6
+	intrigue = 8
+	culture = breton
+	trait = ambitious
+	trait = intricate_webweaver
+	father = 159649
+	810.1.1 = {
+		birth = yes
+	}
+	874.1.1 = {
+		death = yes
+	}
+}
+
+159433 = {
+	name = "Urbien"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159431
+	321.1.1 = {
+		birth = yes
+	}
+	400.1.1 = {
+		death = yes
+	}
+}
+
+159434 = {
+	name = "Gradlon"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159433
+	361.1.1 = {
+		birth = yes
+	}
+	434.1.1 = {
+		death = yes
+		give_nickname = nick_the_great
+	}
+}
+
+159445 = {
+	name = "Clemen"
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159444
+	580.1.1 = {
+		birth = yes
+	}
+	630.1.1 = {
+		death = yes
+	}
+}
+
+159446 = {
+	name = "Petroc"
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159445
+	600.1.1 = {
+		birth = yes
+	}
+	658.1.1 = {
+		death = yes
+	}
+}
+
+159447 = {
+	name = "Culmin"
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159745
+	631.1.1 = {
+		birth = yes
+	}
+	682.1.1 = {
+		death = yes
+	}
+}
+
+159448 = {
+	name = "Dumnarth"
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159447
+	647.1.1 = {
+		birth = yes
+	}
+	700.1.1 = {
+		death = yes
+	}
+}
+
+159449 = {
+	name = "Gereint"
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159448
+	670.1.1 = {
+		birth = yes
+	}
+	710.1.1 = {
+		death = yes
+	}
+}
+
+159450 = {
+	name = "Iudhael"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #For tree appearance
+	father = 159448
+	671.1.1 = {
+		birth = yes
+	}
+	715.1.1 = {
+		death = yes
+	}
+}
+
+159451 = {
+	name = "Donual" # Boifunall
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159450
+	689.1.1 = {
+		birth = yes
+	}
+	742.1.1 = {
+		death = yes
+	}
+}
+
+159452 = {
+	name = "Cawrdolli"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159451
+	705.1.1 = {
+		birth = yes
+	}
+	775.1.1 = {
+		death = yes
+	}
+}
+
+159453 = {
+	name = "Oswallt"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159452
+	725.1.1 = {
+		birth = yes
+	}
+	780.1.1 = {
+		death = yes
+	}
+}
+
+159454 = {
+	name = "Hernam"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159453
+	740.1.1 = {
+		birth = yes
+	}
+	810.1.1 = {
+		death = yes
+	}
+}
+
+159455 = {
+	name = "Hopkin"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159454
+	760.1.1 = {
+		birth = yes
+	}
+	830.1.1 = {
+		death = yes
+	}
+}
+
+159456 = {
+	name = "Mordaf"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159455
+	780.1.1 = {
+		birth = yes
+	}
+	850.1.1 = {
+		death = yes
+	}
+}
+
+159457 = {
+	name = "Ferverdyn"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159456
+	800.1.1 = {
+		birth = yes
+	}
+	865.1.1 = {
+		death = yes
+	}
+}
+
+159458 = {
+	name = "Dumnarth"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159457
+	830.1.1 = {
+		birth = yes
+	}
+	875.1.1 = {
+		death = yes
+	}
+}
+
+159459 = {
+	name = "Eluid"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159457
+	840.1.1 = {
+		birth = yes
+	}
+	889.1.1 = {
+		death = yes
+	}
+}
+
+159460 = {
+	name = "Alan"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159459
+	860.1.1 = {
+		birth = yes
+	}
+	902.1.1 = {
+		death = yes
+	}
+}
+
+159461 = {
+	name = "Hoël"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159460
+	878.1.1 = {
+		birth = yes
+	}
+	932.1.1 = {
+		death = yes
+	}
+}
+
+159462 = {
+	name = "Rolope"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159460
+	890.1.1 = {
+		birth = yes
+	}
+	950.1.1 = {
+		death = yes
+	}
+}
+
+159463 = {
+	name = "Vortegyn Helin"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159462
+	920.1.1 = {
+		birth = yes
+	}
+	980.1.1 = {
+		death = yes
+	}
+}
+
+159464 = {
+	name = "Veffyne"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159463
+	950.1.1 = {
+		birth = yes
+	}
+	1000.1.1 = {
+		death = yes
+	}
+}
+
+159466 = {
+	name = "Conan"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159461
+	900.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+159467 = {
+	name = "Ricat" #Ricatus, Rygys
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159458
+	866.1.1 = {
+		birth = yes
+	}
+	910.1.1 = {
+		death = yes
+	}
+}
+
+159468 = {
+	name = "Alef"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159467
+	905.1.1 = {
+		birth = yes
+	}
+	958.1.1 = {
+		death = yes
+	}
+}
+
+159739 = {
+	name = "Salomon" #Selyf
+	dynasty = 1029042 #
+	religion = catholic
+	culture = breton
+	father = 159466
+
+	919.1.1 = {
+		birth = yes
+	}
+	975.1.1 = {
+		death = yes
+	}
+}
+
+159740 = {
+	name = "Magalatutus"
+	dynasty = 1029042 #
+	religion = catholic
+	culture = breton
+	father = 159739
+
+	936.1.1 = {
+		birth = yes
+	}
+	1015.1.1 = {
+		death = yes
+	}
+}
+
+159741 = {
+	name = "Riwal"
+	dynasty = 1029042 #
+	religion = catholic
+	culture = breton
+	father = 159740
+
+	986.1.1 = {
+		birth = yes
+	}
+	1036.1.1 = {
+		death = yes
+	}
+}
+
+159742 = {
+	name = "Avice"
+	female = yes
+	dynasty = 1029042 #
+	religion = catholic
+	culture = breton
+	father = 161281 # source?
+	mother = 161283
+	1081.6.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+159743 = {
+	name = "Adela"
+	female = yes
+	dynasty = 101754
+	religion = catholic
+	culture = norman
+	father = 158
+	mother = 159742
+	1105.1.1 = {
+		birth = yes
+	}
+	1160.1.1 = {
+		death = yes
+	}
+}
+
+159744 = {
+	name = "Hoël"
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159448
+	668.1.1 = {
+		birth = yes
+	}
+	697.1.1 = {
+		death = yes
+	}
+}
+
+159745 = {
+	name = "Progamel"
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159446
+	616.1.1 = {
+		birth = yes
+	}
+	657.1.1 = {
+		death = yes
+	}
+}
+
+159746 = {
+	name = "Aedaf"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159460
+	892.1.1 = {
+		birth = yes
+	}
+	942.1.1 = {
+		death = yes
+	}
+}
+
+159747 = {
+	name = "Iudhael"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159456
+	835.1.1 = {
+		birth = yes
+	}
+	865.1.1 = {
+		death = yes
+	}
+}
+
+159748 = {
+	name = "Hoël"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159450
+	692.1.1 = {
+		birth = yes
+	}
+	715.1.1 = {
+		death = yes
+	}
+}
+
+159749 = {
+	name = "Rodric"
+	religion = catholic
+	culture = breton
+	dynasty = 1029042 #Corneu
+	father = 159450
+	698.1.1 = {
+		birth = yes
+	}
+	747.1.1 = {
+		death = yes
+	}
+}
+
+159750 = {
+	name = "Blethin" #Bleddyn
+	religion = catholic
+	culture = breton
+	dynasty = 1029041
+	father = 159444
+	583.1.1 = {
+		birth = yes
+	}
+	628.1.1 = {
+		death = yes
+	}
+}
+
+159634 = {
+	name = "Guitol" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159434
+	381.1.1 = {
+		birth = yes
+	}
+	450.1.1 = {
+		death = yes
+	}
+}
+
+159635 = {
+	name = "Deroch" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159634
+	400.1.1 = {
+		birth = yes
+	}
+	470.1.1 = {
+		death = yes
+	}
+}
+
+159636 = {
+	name = "Riotham" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159635
+	435.1.1 = {
+		birth = yes
+	}
+	480.1.1 = {
+		death = yes
+	}
+}
+
+159637 = {
+	name = "Riwal" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159636
+	475.1.1 = {
+		birth = yes
+	}
+	520.1.1 = {
+		death = yes
+	}
+}
+
+159638 = {
+	name = "Deroch" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159637
+	495.1.1 = {
+		birth = yes
+	}
+	530.1.1 = {
+		death = yes
+	}
+}
+
+159639 = {
+	name = "Ionas" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159638
+	515.1.1 = {
+		birth = yes
+	}
+	540.1.1 = {
+		death = yes
+	}
+}
+
+159640 = {
+	name = "Iudual" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159639
+	535.1.1 = {
+		birth = yes
+	}
+	590.1.1 = {
+		death = yes
+	}
+}
+
+159641 = {
+	name = "Iudhael" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029101 #Domnonea
+	father = 159640
+	560.1.1 = {
+		birth = yes
+	}
+	607.1.1 = {
+		death = yes
+	}
+}
+
+159642 = {
+	name = "Riwallon" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159641
+	590.1.1 = {
+		birth = yes
+	}
+	667.1.1 = {
+		death = yes
+	}
+}
+
+159643 = {
+	name = "Guérech" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159642
+	620.1.1 = {
+		birth = yes
+	}
+	692.1.1 = {
+		death = yes
+	}
+}
+
+159644 = {
+	name = "Riwallon" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159643
+	650.1.1 = {
+		birth = yes
+	}
+	720.1.1 = {
+		death = yes
+	}
+}
+
+159645 = {
+	name = "Deniel" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159644
+	690.1.1 = {
+		birth = yes
+	}
+	749.1.1 = {
+		death = yes
+	}
+}
+
+159646 = {
+	name = "Budic" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159645
+	720.1.1 = {
+		birth = yes
+		add_claim = c_rennes
+	}
+	780.1.1 = {
+		death = yes
+	}
+}
+
+159648 = {
+	name = "Melliau" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159646
+	740.1.1 = {
+		birth = yes
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+159647 = {
+	name = "Erispoë" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159646
+	760.1.1 = {
+		birth = yes
+	}
+	812.1.1 = {
+		death = yes
+	}
+}
+
+159698 = {
+	name = "Alan"
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159651
+	850.1.1 = {
+		birth = yes
+	}
+	880.1.1 = {
+	dynasty = 1029103 #de Rieux
+	}
+	907.1.1 = {
+		death = yes
+	}
+}
+
+159699 = {
+	name = "Rudalt"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159698
+	880.1.1 = {
+		birth = yes
+	}
+	917.1.1 = {
+		death = yes
+	}
+}
+
+159700 = {
+	name = "Alan"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159699
+	910.1.1 = {
+		birth = yes
+	}
+	987.1.1 = {
+		death = yes
+	}
+}
+
+159701 = {
+	name = "Rudalt"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159700
+	950.1.1 = {
+		birth = yes
+	}
+	1021.1.1 = {
+		death = yes
+	}
+}
+
+159702 = {
+	name = "Alan"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159701
+	980.1.1 = {
+		birth = yes
+	}
+	1051.1.1 = {
+		death = yes
+	}
+}
+
+159703 = {
+	name = "Rudalt"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159702
+	1020.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		death = yes
+	}
+}
+
+159704 = {
+	name = "Iocilin"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159703
+	1045.1.1 = {
+		birth = yes
+	}
+	1107.1.1 = {
+		death = yes
+	}
+}
+
+159705 = {
+	name = "Raoul"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159703
+	1045.1.1 = {
+		birth = yes
+	}
+	1064.1.1 = {
+		death = yes
+	}
+}
+
+159706 = {
+	name = "Alan"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159705
+	1064.1.1 = {
+		birth = yes
+	}
+	1124.1.1 = {
+		death = yes
+	}
+}
+
+159707 = {
+	name = "Guéthenoc"
+	religion = catholic
+	culture = breton
+	dynasty = 1029103 #de Rieux
+	father = 159704
+	1061.1.1 = {
+		birth = yes
+	}
+	1127.1.1 = {
+		death = yes
+	}
+}
+
+159649 = {
+	name = "Riwallon" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159647
+	790.1.1 = {
+		birth = yes
+	}
+	857.1.1 = {
+		death = yes
+	}
+}
+
+159651 = {
+	name = "Riwallon" #
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 163105
+	830.1.1 = {
+		birth = yes
+	}
+	877.1.1 = {
+		death = yes
+	}
+}
+
+159633 = {
+	name = "Salomon"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159434
+	380.1.1 = {
+		birth = yes
+	}
+	446.1.1 = {
+		death = yes
+	}
+}
+
+159652 = {
+	name = "Aldrien"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159633
+	400.1.1 = {
+		birth = yes
+	}
+	464.1.1 = {
+		death = yes
+	}
+}
+
+159657 = {
+	name = "Iehan Riotham"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159652
+	420.1.1 = {
+		birth = yes
+	}
+	470.1.1 = {
+		death = yes
+	}
+}
+
+159658 = {
+	name = "Salomon"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159652
+	410.1.1 = {
+		birth = yes
+	}
+	464.1.1 = {
+		death = yes
+	}
+}
+
+159756 = {
+	name = "Guérech"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159652
+	425.1.1 = {
+		birth = yes
+	}
+	494.1.1 = {
+		death = yes
+	}
+}
+
+159659 = {
+	name = "Budic"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159652
+	420.1.1 = {
+		birth = yes
+	}
+	478.1.1 = {
+		death = yes
+	}
+}
+
+159660 = {
+	name = "Budic"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159756
+	460.1.1 = {
+		birth = yes
+	}
+	544.1.1 = {
+		death = yes
+	}
+}
+
+159661 = {
+	name = "Emyric"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159657
+	440.1.1 = {
+		birth = yes
+	}
+	500.1.1 = {
+		death = yes
+	}
+}
+
+159662 = {
+	name = "Hoël"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159660
+	491.1.1 = {
+		birth = yes
+	}
+	520.1.1 = {
+		add_spouse = 160048
+	}
+	545.1.1 = {
+		death = yes
+	}
+}
+
+159757 = {
+	name = "Teudur"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159662
+	mother = 160048
+	520.1.1 = {
+		birth = yes
+	}
+	546.1.1 = {
+		death = yes
+		give_nickname = nick_the_great
+	}
+}
+
+159663 = {
+	name = "Hoël"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159662
+	mother = 160048
+	522.1.1 = {
+		birth = yes
+	}
+	547.1.1 = {
+		death = yes
+	}
+}
+
+159664 = {
+	name = "Alan"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159663
+	540.1.1 = {
+		birth = yes
+	}
+	594.1.1 = {
+		death = yes
+	}
+}
+
+159665 = {
+	name = "Hoël"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159664
+	560.1.1 = {
+		birth = yes
+	}
+	612.1.1 = {
+		death = yes
+	}
+}
+
+159666 = {
+	name = "Salomon"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159665
+	580.1.1 = {
+		birth = yes
+	}
+	630.1.1 = {
+		death = yes
+	}
+}
+
+159667 = {
+	name = "Iudicael"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159665
+	590.1.1 = {
+		birth = yes
+	}
+	658.12.17 = {
+		death = yes
+	}
+}
+
+159668 = {
+	name = "Gradlon"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159667
+	632.1.1 = {
+		birth = yes
+	}
+	680.1.1 = {
+		death = yes
+	}
+}
+
+159669 = {
+	name = "Concar"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159668
+	660.1.1 = {
+		birth = yes
+	}
+	720.1.1 = {
+		death = yes
+	}
+}
+
+159670 = {
+	name = "Iudon"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159669
+	710.1.1 = {
+		birth = yes
+	}
+	760.1.1 = {
+		death = yes
+	}
+}
+
+159671 = {
+	name = "Custentin" #Constantine
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159670
+	740.1.1 = {
+		birth = yes
+	}
+	820.1.1 = {
+		death = yes
+	}
+}
+
+159672 = {
+	name = "Gestin" #Justin
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159671
+	769.1.1 = {
+		birth = yes
+	}
+	840.1.1 = {
+		death = yes
+	}
+}
+
+159673 = {
+	name = "Alfrond"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159672
+	800.1.1 = {
+		birth = yes
+	}
+	880.1.1 = {
+		death = yes
+	}
+}
+
+159674 = {
+	name = "Ulfret"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159673
+	840.1.1 = {
+		birth = yes
+	}
+	920.1.1 = {
+		death = yes
+	}
+}
+
+159675 = {
+	name = "Diles"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159674
+	880.1.1 = {
+		birth = yes
+	}
+	955.1.1 = {
+		death = yes
+	}
+}
+
+159676 = {
+	name = "Budic"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159675
+	910.1.1 = {
+		birth = yes
+	}
+	970.1.1 = {
+		death = yes
+	}
+}
+
+159677 = {
+	name = "Budic"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159676
+	940.1.1 = {
+		birth = yes
+	}
+	1031.1.1 = {
+		death = yes
+	}
+}
+
+159678 = {
+	name = "Budic"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159677
+	957.1.1 = {
+		birth = yes
+	}
+	1041.1.1 = {
+		death = yes
+	}
+}
+
+159653 = {
+	name = "Guérech"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159652
+	425.1.1 = {
+		birth = yes
+	}
+	478.1.1 = {
+		death = yes
+	}
+}
+
+159654 = {
+	name = "Budic"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159653
+	460.1.1 = {
+		birth = yes
+	}
+	501.1.1 = {
+		death = yes
+	}
+}
+
+159655 = {
+	name = "Budic"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159654
+	490.1.1 = {
+		birth = yes
+	}
+	541.1.1 = {
+		death = yes
+	}
+}
+
+159656 = {
+	name = "Teudric" #Theodoric
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159655
+	520.1.1 = {
+		birth = yes
+	}
+	584.1.1 = {
+		death = yes
+	}
+}
+
+159679 = {
+	name = "Even" # Eugene
+	religion = catholic
+	culture = breton
+	dynasty = 20017 # de Leon
+	father = 159690
+	957.1.1 = {
+		birth = yes
+	}
+	1041.1.1 = {
+		death = yes
+	}
+}
+
+159680 = {
+	name = "Alan" # II the Tall
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159667
+	620.1.1 = {
+		birth = yes
+	}
+	690.1.1 = {
+		death = yes
+	}
+}
+
+159681 = {
+	name = "Iehan" # John
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159680
+	672.1.1 = {
+		birth = yes
+	}
+	730.1.1 = {
+		death = yes
+	}
+}
+
+159682 = {
+	name = "Deniel" # I Dremrust
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159681
+	690.1.1 = {
+		birth = yes
+	}
+	749.1.1 = {
+		death = yes
+	}
+}
+
+159683 = {
+	name = "Raulhon"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159682
+	710.1.1 = {
+		birth = yes
+	}
+	750.1.1 = {
+		death = yes
+	}
+}
+
+159684 = {
+	name = "Deniel" # II Dremrust
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159683
+	730.1.1 = {
+		birth = yes
+	}
+	762.1.1 = {
+		death = yes
+	}
+}
+
+159685 = {
+	name = "Berdic"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159684
+	750.1.1 = {
+		birth = yes
+		add_claim = c_nantes
+	}
+	799.1.1 = {
+		death = yes
+	}
+}
+
+159686 = {
+	name = "Morvan"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159685
+	790.1.1 = {
+		birth = yes
+	}
+	824.1.1 = {
+		death = yes
+	}
+}
+
+159687 = {
+	name = "Guihomarch"
+	religion = catholic
+	culture = breton
+	dynasty = 1051999 # de Leon
+	father = 159686
+	820.1.1 = {
+		birth = yes
+	}
+	874.1.1 = {
+		death = yes
+	}
+}
+
+159688 = {
+	name = "Erispoë" #
+	religion = catholic
+	culture = breton
+	dynasty = 1051999 # de Leon
+	father = 159687
+	850.1.1 = {
+		birth = yes
+	}
+	914.1.1 = {
+		death = yes
+	}
+}
+
+159689 = {
+	name = "Hamon" #
+	religion = catholic
+	culture = breton
+	dynasty = 1051999 # de Leon
+	father = 159688
+	885.1.1 = {
+		birth = yes
+	}
+	924.1.1 = {
+		death = yes
+	}
+}
+
+159690 = {
+	name = "Pirinis"
+	religion = catholic
+	culture = breton
+	dynasty = 1051999 # de Leon
+	father = 159689
+	920.1.1 = {
+		birth = yes
+	}
+	984.1.1 = {
+		death = yes
+	}
+}
+
+159691 = {
+	name = "Erispoë"
+	religion = catholic
+	culture = breton
+	dynasty = 1029102 #de Poher
+	father = 159648
+	760.1.1 = {
+		birth = yes
+	}
+	824.1.1 = {
+		death = yes
+	}
+}
+
+159692 = {
+	name = "Guihomarch" #
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159685
+	766.1.1 = {
+		birth = yes
+	}
+	804.1.1 = {
+		death = yes
+	}
+}
+
+159693 = {
+	name = "Erispoë" #Harispogius,
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159692
+	785.1.1 = {
+		birth = yes
+	}
+	834.1.1 = {
+		death = yes
+	}
+}
+
+159694 = {
+	name = "Nominoë" #Nevenoe
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159693
+	800.1.1 = {
+		birth = yes
+	}
+	851.1.1 = {
+		death = yes
+	}
+}
+
+159695 = {
+	name = "Pascueten" #Pasquitan, Paskweten
+	religion = catholic
+	culture = breton
+	dynasty = 20137 #Vannes
+	father = 159694
+	818.1.1 = {
+		birth = yes
+	}
+	877.1.1 = {
+		death = yes
+	}
+}
+
+159696 = {
+	name = "Guruant" #Gurvand
+	religion = catholic
+	culture = breton
+	dynasty = 22006 #Rennes
+	father = 159694
+	820.1.1 = {
+		birth = yes
+	}
+	877.1.1 = {
+		death = yes
+	}
+}
+
+159965 = {
+	name = "ErispoÎ"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159694
+	816.1.1 = {
+		birth = yes
+	}
+	845.1.1 = {
+		add_spouse = 252342
+	}
+	857.1.1 = {
+		death = yes
+	}
+}
+
+160071 = {
+	name = "Oreguen"
+	female = yes
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159673
+	865.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+160072 = {
+	name = "Argant"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159671
+	791.1.1 = {
+		birth = yes
+	}
+	840.1.1 = {
+		death = yes
+	}
+}
+
+160073 = {
+	name = "Iudhael"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159672
+	825.1.1 = {
+		birth = yes
+	}
+	880.1.1 = {
+		death = yes
+	}
+}
+
+160074 = {
+	name = "Rivod"
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159672
+	826.1.1 = {
+		birth = yes
+	}
+	885.1.1 = {
+		death = yes
+	}
+}
+
+160075 = {
+	name = "Louenan" #Louvenan, Lowenen
+	religion = catholic
+	culture = breton
+	dynasty = 311 # de Cornouaille
+	father = 159673
+	850.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+160076 = {
+	name = "Berenger" #
+	dynasty = 22006 #Rennes
+	religion = catholic
+	culture = breton
+	father = 159696
+	861.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+160077 = {
+	name = "Ridoredh" #
+	dynasty = 20106 #Naoned
+	religion = catholic
+	culture = breton
+	father = 159965
+	mother = 252342
+	martial = 8
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 6
+	trait = ambitious
+	trait = diligent
+	trait = patient
+	trait = humble
+	trait = skilled_tactician
+	849.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+160078 = {
+	name = "Gourmaelon" #
+	dynasty = 20106 #Naoned
+	religion = catholic
+	culture = breton
+	father = 160077
+	865.1.1 = {
+		birth = yes
+	}
+	867.1.1 = {
+		employer = 163105 # Duke of Brittany
+	}
+	913.1.1 = {
+		death = yes
+	}
+}
+
+160079 = {
+	name = "Pascueten" #
+	dynasty = 20106 #Naoned
+	religion = catholic
+	culture = breton
+	father = 160077
+	866.1.1 = {
+		birth = yes
+	}
+	867.1.1 = {
+		employer = 163105 # Duke of Brittany
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+160047 = {
+	name = "Agatha" #
+	female = yes
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159680
+	680.1.1 = {
+		birth = yes
+	}
+	700.1.1 = {
+		add_spouse = 159020
+	}
+	750.1.1 = {
+		death = yes
+	}
+}
+
+180048 = {
+	name = "Alain"
+	dynasty = 3134
+	religion = catholic
+	culture = breton
+	1009.1.1 = {
+		birth = yes
+	}
+	1061.1.1 = {
+		death = yes
+	}
+}
+
+180049 = {
+	name = "Flaad"
+	dynasty = 3134
+	religion = catholic
+	culture = breton
+	father = 180048
+	1038.1.1 = {
+		birth = yes
+	}
+	1105.1.1 = {
+		death = yes
+	}
+}
+
+189430 = {
+	name = "Gradlon" #
+	dynasty = 10290904
+	religion = catholic
+	culture = breton
+	father = 159669
+	713.1.1 = {
+		birth = yes
+	}
+	758.1.1 = {
+		death = yes
+	}
+}
+
+189431 = {
+	name = "Morvan" #
+	dynasty = 10290904
+	religion = catholic
+	culture = breton
+	father = 189430
+	740.1.1 = {
+		birth = yes
+	}
+	788.1.1 = {
+		death = yes
+	}
+}
+
+189432 = {
+	name = "Concar" #
+	dynasty = 10290904
+	religion = catholic
+	culture = breton
+	father = 189431
+	765.1.1 = {
+		birth = yes
+	}
+	820.1.1 = {
+		death = yes
+	}
+}
+
+252325 = {
+	name = "GuÈrech" # Gwereg/Waroch I
+	dynasty = 1029129 #Gwent
+	religion = catholic
+	culture = welsh
+	father = 159823
+	mother = 159960
+	495.1.1 = {
+		birth = yes
+	}
+	530.1.1 = {
+		culture = breton
+		dynasty = 105945 #Bro Erec
+	}
+	550.1.1 = {
+		death = yes
+	}
+}
+
+252326 = {
+	name = "Tryphine" # Saint Tryphine (wife of Conomor of Dumnonia)
+	female = yes
+	dynasty = 105945 #Bro Erec
+	religion = catholic
+	culture = breton
+	father = 252325
+	530.1.1 = {
+		birth = yes
+	}
+	550.1.1 = {
+		death = yes
+	}
+}
+
+252327 = {
+	name = "Chanao" # Canao/Chanao I
+	dynasty = 105945 #Bro Erec
+	religion = catholic
+	culture = breton
+	father = 252325
+	532.1.1 = {
+		birth = yes
+	}
+	570.1.1 = {
+		death = yes
+	}
+}
+
+252328 = {
+	name = "Macliau" # Macliau
+	dynasty = 105945 #Bro Erec
+	religion = catholic
+	culture = breton
+	father = 252325
+	534.1.1 = {
+		birth = yes
+	}
+	577.1.1 = {
+		death = yes
+	}
+}
+
+252329 = {
+	name = "Iacob" # Jacob/Iacob
+	dynasty = 105945 #Bro Erec
+	religion = catholic
+	culture = breton
+	father = 252328
+	552.1.1 = {
+		birth = yes
+	}
+	577.4.1 = {
+		death = yes
+	}
+}
+
+252330 = {
+	name = "GuÈrech" # Gwereg/Waroch II
+	dynasty = 105945 #Bro Erec
+	religion = catholic
+	culture = breton
+	father = 252328
+	554.1.1 = {
+		birth = yes
+	}
+	595.1.1 = {
+		death = yes
+	}
+}
+
+252331 = {
+	name = "Chanao" # Canao/Chanao II
+	dynasty = 105945 #Bro Erec
+	religion = catholic
+	culture = breton
+	father = 252330
+	576.1.1 = {
+		birth = yes
+	}
+	635.1.1 = {
+		death = yes
+	}
+}
+
+#Sons of Budic I
+252332 = {
+	name = "Melliau"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159659
+	442.1.1 = {
+		birth = yes
+	}
+	471.1.1 = {
+		death = yes
+	}
+}
+
+252333 = {
+	name = "Rhiwod"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159659
+	444.1.1 = {
+		birth = yes
+	}
+	472.1.1 = {
+		death = yes
+	}
+}
+
+252334 = {
+	name = "Mélar"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 252332
+	460.1.1 = {
+		birth = yes
+	}
+	530.1.1 = {
+		death = yes
+	}
+}
+
+252335 = {
+	name = "Deniel" #Deniel Unua
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 252333
+	465.1.1 = {
+		birth = yes
+	}
+	545.1.1 = {
+		death = yes
+	}
+}
+
+#Early Breton Leon
+252336 = {
+	name = "Rivold"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 159660
+	494.1.1 = {
+		birth = yes
+	}
+	540.1.1 = {
+		death = yes
+	}
+}
+
+252337 = {
+	name = "Withur"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 252336
+	515.1.1 = {
+		birth = yes
+	}
+	570.1.1 = {
+		death = yes
+	}
+}
+
+252338 = {
+	name = "Ausoch"
+	religion = catholic
+	culture = breton
+	dynasty = 20124 #Breizh
+	father = 252337
+	537.1.1 = {
+		birth = yes
+	}
+	590.1.1 = {
+		death = yes
+	}
+}
+
+#Poher
+260481 = {
+	name = "Cynfawr"
+	religion = catholic
+	culture = welsh
+	dynasty = 1029040 #Dyfnaint
+	father = 159441
+	502.1.1 = {
+		birth = yes
+	}
+	520.1.1 = {
+		name = "Conomor"
+		culture = breton
+	}
+	546.1.1 = {
+		add_spouse = 252326
+	}
+	560.1.1 = {
+		death = yes
+	}
+}
+
+252339 = {
+	name = "Trémeur"
+	religion = catholic
+	culture = breton
+	dynasty = 1029040 #Dyfnaint
+	father = 260481
+	mother = 252326
+	548.1.1 = {
+		birth = yes
+	}
+	555.1.1 = {
+		death = yes
+	}
+}
+
+#missing son of Erispoe the Elder
+252340 = {
+	name = "Riwallon" #Riwallon
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 159693
+	802.1.1 = {
+		birth = yes
+	}
+	857.1.1 = {
+		death = yes
+	}
+}
+
+252341 = {
+	name = "GuÈrech" #GuÈrech
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 252340
+	820.1.1 = {
+		birth = yes
+	}
+	874.1.1 = {
+		death = yes
+	}
+}
+
+252342 = {
+	name = "Marmoëc" #Marmoëc
+	female = yes
+	religion = catholic
+	culture = breton
+	dynasty = 20124 # Breizh
+	father = 252340
+	825.1.1 = {
+		birth = yes
+	}
+	856.1.1 = {
+		death = yes
+	}
+}
+
+#Kernow
+252343 = {
+	name = "Cyngar" # Cyngar/Congar
+	dynasty = 1029130 #Cernyw
+	religion = catholic
+	culture = welsh
+	father = 159826
+	400.1.1 = {
+		birth = yes
+	}
+	448.1.1 = {
+		name = "Congar"
+		culture = breton
+	}
+	490.1.1 = {
+		death = yes
+	}
+}
+
+252344 = {
+	name = "Deniel" # Deniel Drem Rud
+	dynasty = 105948 # Kernev
+	religion = catholic
+	culture = breton
+	father = 252343
+	450.1.1 = {
+		birth = yes
+	}
+	515.1.1 = {
+		death = yes
+	}
+}
+
+252345 = {
+	name = "Iahan" # Iahan Reith
+	dynasty = 105948 # Kernev
+	religion = catholic
+	culture = breton
+	father = 252344
+	515.1.1 = {
+		birth = yes
+	}
+	591.1.1 = {
+		death = yes
+	}
+}
+
+252346 = {
+	name = "Deniel" # Deniel Unua
+	dynasty = 105946 # Kernev
+	religion = catholic
+	culture = breton
+	father = 252345
+	550.1.1 = {
+		birth = yes
+	}
+	625.1.1 = {
+		death = yes
+	}
+}

--- a/CK2Plus_expanded/history/characters/german.txt
+++ b/CK2Plus_expanded/history/characters/german.txt
@@ -54851,7 +54851,7 @@
 
 256041 = { 		#Berthold of Hannover, 2nd bishop of Riga
 	name = "Berthold"
-	dynasty = 1061019
+	dynasty = 1061029
 	religion = catholic
 	culture = german
 	1136.1.1 = {

--- a/CK2Plus_expanded/history/characters/lombard.txt
+++ b/CK2Plus_expanded/history/characters/lombard.txt
@@ -1,0 +1,6955 @@
+190122 = {
+	name = "Audoin"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	519.1.1 = {
+		birth = yes
+	}
+	536.1.1 = {
+		add_spouse = 190123
+	}
+	565.1.1 = {
+		death = yes
+	}
+}
+
+190123 = {
+	name = "Rodelinda"
+	female = yes
+	dynasty = 1044032 #Theoderingi
+	religion = catholic
+	culture = lombard
+	520.1.1 = {
+		birth = yes
+	}
+	574.1.1 = {
+		death = yes
+	}
+}
+
+190124 = {
+	name = "Alboin"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190122
+	mother = 190123
+	539.1.1 = {
+		birth = yes
+	}
+	572.1.1 = {
+		death = yes
+	}
+}
+
+190125 = {
+	name = "Grasulf"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190122
+	mother = 190123
+	542.1.1 = {
+		birth = yes
+	}
+	569.1.1 = {
+		death = yes
+	}
+}
+
+190126 = {
+	name = "Gisulf"#duke of Friuli
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190125
+	559.1.1 = {
+		birth = yes
+	}
+	591.1.1 = {
+		death = yes
+	}
+}
+
+190127 = {
+	name = "Zotto" #duke of Benevento
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190125
+	560.1.1 = {
+		birth = yes
+	}
+	576.1.1 = {
+		add_spouse = 190166
+	}
+	591.1.1 = {
+		death = yes
+	}
+}
+
+190128 = {
+	name = "Gisulf" #II duke of Friuli
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190126
+	578.1.1 = {
+		birth = yes
+	}
+	594.1.1 = {
+		add_spouse = 190129
+	}
+	610.1.1 = {
+		death = yes
+	}
+}
+
+190244 = {
+	name = "Taso" #duke of Friuli
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190128
+	mother = 190129
+	594.1.1 = {
+		birth = yes
+	}
+	625.1.1 = {
+		death = yes
+	}
+}
+
+190245 = {
+	name = "Cacco"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190128
+	mother = 190129
+	595.1.1 = {
+		birth = yes
+	}
+	625.1.1 = {
+		death = yes
+	}
+}
+
+190130 = {
+	name = "Radoald"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190128
+	mother = 190129
+	596.1.1 = {
+		birth = yes
+	}
+	651.1.1 = {
+		death = yes
+	}
+}
+
+190131 = {
+	name = "Appa" #wife of king of Alemanni
+	female = yes
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190128
+	mother = 190129
+	598.1.1 = {
+		birth = yes
+	}
+	652.1.1 = {
+		death = yes
+	}
+}
+
+190132 = {
+	name = "Geila" #wife of Garibald II king of Bavaria
+	female = yes
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190128
+	mother = 190129
+	603.1.1 = {
+		birth = yes
+	}
+	657.1.1 = {
+		death = yes
+	}
+}
+
+190133 = {
+	name = "Grimoald" #king of lombards
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190128
+	mother = 190129
+	609.1.1 = {
+		birth = yes
+	}
+	650.1.1 = {
+		add_spouse = 190134
+	}
+	671.1.1 = {
+		death = yes
+	}
+}
+
+190134 = {
+	name = "Theodota" #daughter of Aripert II king of Lombards
+	female = yes
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190181
+	634.1.1 = {
+		birth = yes
+	}
+	675.1.1 = {
+		death = yes
+	}
+}
+
+190135 = {
+	name = "Romuald"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190133
+	mother = 190134
+	653.1.1 = {
+		birth = yes
+	}
+	669.1.1 = {
+		add_spouse = 190137
+	}
+	687.1.1 = {
+		death = yes
+	}
+}
+
+190136 = {
+	name = "Garibald"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190133
+	mother = 190134
+	655.1.1 = {
+		birth = yes
+	}
+	688.1.1 = {
+		death = yes
+	}
+}
+
+190137 = {
+	name = "Theodrada" #daughter of Lupus of Friuli
+	female = yes
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190248
+	653.1.1 = {
+		birth = yes
+	}
+	698.1.1 = {
+		death = yes
+	}
+}
+
+190138 = {
+	name = "Grimoald"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190135
+	mother = 190137
+	669.1.2 = {
+		birth = yes
+	}
+	685.1.1 = {
+		add_spouse = 190187
+	}
+	689.1.1 = {
+		death = yes
+	}
+}
+
+190139 = {
+	name = "Gisulf"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190135
+	mother = 190137
+	670.1.1 = {
+		birth = yes
+	}
+	686.1.1 = {
+		add_spouse = 190140
+	}
+	706.1.1 = {
+		death = yes
+	}
+}
+
+190140 = {
+	name = "Winperga"
+	female = yes
+	dynasty = 1044036 #Lampertingi
+	religion = catholic
+	culture = lombard
+	669.1.1 = {
+		birth = yes
+	}
+	712.1.1 = {
+		death = yes
+	}
+}
+
+190141 = {
+	name = "Romuald"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190139
+	mother = 190140
+	686.1.2 = {
+		birth = yes
+	}
+	702.1.1 = {
+		add_spouse = 190142
+	}
+	729.1.1 = {
+		remove_spouse = 190142
+	}
+	730.1.1 = {
+		add_spouse = 190143
+	}
+	732.1.1 = {
+		death = yes
+	}
+}
+
+190142 = {
+	name = "Gumperga" #daughter of Aurona sister of King Liutprand
+	female = yes
+	dynasty = 1044037 #Giselbertling
+	religion = catholic
+	culture = lombard
+	684.1.1 = {
+		birth = yes
+	}
+	729.1.1 = {
+		death = yes
+	}
+}
+
+190143 = {
+	name = "Ranigunda" #daughter of Duke Gaiduld of Brescia
+	female = yes
+	dynasty = 1044038 #Gaiduldling
+	religion = catholic
+	culture = lombard
+	709.1.1 = {
+		birth = yes
+	}
+	741.1.1 = {
+		death = yes
+	}
+}
+
+190144 = {
+	name = "Gisulf"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190141
+	mother = 190142
+	702.1.1 = {
+		birth = yes
+	}
+	718.1.1 = {
+		add_spouse = 190145
+	}
+	751.1.1 = {
+		death = yes
+	}
+}
+
+190145 = {
+	name = "Scauniperga"
+	female = yes
+	dynasty = 1044039 #Waldulfingi
+	religion = catholic
+	culture = lombard
+	701.1.1 = {
+		birth = yes
+	}
+	752.1.1 = {
+		death = yes
+	}
+}
+
+190146 = {
+	name = "Liutprand"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190144
+	mother = 190145
+	719.1.1 = {
+		birth = yes
+	}
+	756.1.1 = {
+		death = yes
+	}
+}
+
+190147 = {
+	name = "Arechis"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190146
+	735.1.1 = {
+		birth = yes
+	}
+	751.1.1 = {
+		add_spouse = 190148
+	}
+	787.8.26 = {
+		death = yes
+	}
+}
+
+190148 = {
+	name = "Adelperga" #Daughter of Desiderius
+	female = yes
+	dynasty = 1044053 #Alachisling
+	religion = catholic
+	culture = lombard
+	father = 190347
+	mother = 190340
+	735.1.1 = {
+		birth = yes
+	}
+	772.1.1 = {
+		death = yes
+	}
+}
+
+190149 = {
+	name = "Romoald"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190147
+	mother = 190148
+	751.1.1 = {
+		birth = yes
+	}
+	787.8.26 = {
+		death = yes
+	}
+}
+
+190150 = {
+	name = "Grimoald"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190147
+	mother = 190148
+	752.1.1 = {
+		birth = yes
+	}
+	767.1.1 = {
+		add_spouse = 190151
+	}
+	806.1.1 = {
+		death = yes
+	}
+}
+
+190151 = {
+	name = "Scauniperga" #fictional
+	female = yes
+	dynasty = 1044041 #Romoaldingi
+	religion = catholic
+	culture = lombard
+	750.1.1 = {
+		birth = yes
+	}
+	809.1.1 = {
+		death = yes
+	}
+}
+
+190152 = {
+	name = "Ilderic"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190150
+	mother = 190151
+	768.1.1 = {
+		birth = yes
+	}
+	807.1.1 = {
+		death = yes
+	}
+}
+
+190153 = {
+	name = "Arechis" #duke of Benevento
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190126
+	581.1.1 = {
+		birth = yes
+	}
+	641.1.1 = {
+		death = yes
+	}
+}
+
+190154 = {
+	name = "Aiulf"
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190153
+	601.1.1 = {
+		birth = yes
+	}
+	646.1.1 = {
+		death = yes
+	}
+}
+
+190246 = {
+	name = "Grasulf" #duke of Friuli
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190126
+	579.1.1 = {
+		birth = yes
+	}
+	641.1.1 = {
+		death = yes
+	}
+}
+
+190247 = {
+	name = "Ago" #duke of Friuli
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190246
+	599.1.1 = {
+		birth = yes
+	}
+	663.1.1 = {
+		death = yes
+	}
+}
+
+190248 = {
+	name = "Lupus" #duke of Friuli
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190247
+	620.1.1 = {
+		birth = yes
+	}
+	666.1.1 = {
+		death = yes
+	}
+}
+
+190249 = {
+	name = "Arnefrit" #duke of Friuli
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190248
+	638.1.1 = {
+		birth = yes
+	}
+	666.6.1 = {
+		death = yes
+	}
+}
+
+190250 = {
+	name = "Wechtar" #duke of Friuli
+	dynasty = 1044059 #Wechtaringi
+	religion = catholic
+	culture = lombard
+	636.1.1 = {
+		birth = yes
+	}
+	678.1.1 = {
+		death = yes
+	}
+}
+
+190251 = {
+	name = "Landar" #duke of Friuli
+	dynasty = 1044059 #Wechtaringi
+	religion = catholic
+	culture = lombard
+	father = 190250
+	652.1.1 = {
+		birth = yes
+	}
+	690.1.1 = {
+		death = yes
+	}
+}
+
+190252 = {
+	name = "Rodoald" #duke of Friuli
+	dynasty = 1044059 #Wechtaringi
+	religion = catholic
+	culture = lombard
+	father = 190251
+	668.1.1 = {
+		birth = yes
+	}
+	694.1.1 = {
+		death = yes
+	}
+}
+
+190253 = {
+	name = "Landeburga" #wife of Ansfrid of Friuli
+	female = yes
+	dynasty = 1044059 #Wechtaringi
+	religion = catholic
+	culture = lombard
+	father = 190251
+	669.1.1 = {
+		birth = yes
+	}
+	730.1.1 = {
+		death = yes
+	}
+}
+
+190254 = {
+	name = "Ado" #duke of Friuli
+	dynasty = 1044059 #Wechtaringi
+	religion = catholic
+	culture = lombard
+	father = 190251
+	678.1.1 = {
+		birth = yes
+	}
+	695.1.1 = {
+		death = yes
+	}
+}
+
+190255 = {
+	name = "Ansfrid" #duke of Friuli
+	dynasty = 1044060 #Ansfridingi
+	religion = catholic
+	culture = lombard
+	656.1.1 = {
+		birth = yes
+	}
+	685.1.1 = {
+		add_spouse = 190253
+	}
+	694.1.1 = {
+		death = yes
+	}
+}
+
+190256 = {
+	name = "Ferdulf" #duke of Friuli
+	dynasty = 1044060 #Ansfridingi
+	religion = catholic
+	culture = lombard
+	father = 190255
+	mother = 190253
+	685.1.1 = {
+		birth = yes
+	}
+	705.1.1 = {
+		death = yes
+	}
+}
+
+190257 = {
+	name = "Corvulus" #duke of Friuli
+	dynasty = 1044060 #Ansfridingi
+	religion = catholic
+	culture = lombard
+	father = 190256
+	701.1.1 = {
+		birth = yes
+	}
+	760.1.1 = {
+		death = yes
+	}
+}
+
+190258 = {
+	name = "Ferdulf"
+	dynasty = 1044060 #Ansfridingi
+	religion = catholic
+	culture = lombard
+	father = 190257
+	721.1.1 = {
+		birth = yes
+	}
+	773.1.1 = {
+		death = yes
+	}
+}
+
+190259 = {
+	name = "Munichis"
+	dynasty = 1044052 #Munichingi
+	religion = catholic
+	culture = lombard
+	701.1.1 = {
+		birth = yes
+	}
+	740.1.1 = {
+		death = yes
+	}
+}
+
+190260 = {
+	name = "Anselm" #duke of Friuli
+	dynasty = 1044052 #Munichingi
+	religion = catholic
+	culture = lombard
+	father = 190259
+	718.1.1 = {
+		birth = yes
+	}
+	806.1.1 = {
+		death = yes
+	}
+}
+
+190261 = {
+	name = "Munichis"
+	dynasty = 1044052 #Munichingi
+	religion = catholic
+	culture = lombard
+	father = 190259
+	719.1.1 = {
+		birth = yes
+	}
+	748.1.1 = {
+		death = yes
+	}
+}
+
+190262 = {
+	name = "Peter" #duke of friuli
+	dynasty = 1044052 #Munichingi
+	religion = catholic
+	culture = lombard
+	father = 190261
+	735.1.1 = {
+		birth = yes
+	}
+	774.1.1 = {
+		death = yes
+	}
+}
+
+190263 = {
+	name = "Ursus" #count of Padua
+	dynasty = 1044052 #Munichingi
+	religion = catholic
+	culture = lombard
+	father = 190261
+	737.1.1 = {
+		birth = yes
+	}
+	774.1.1 = {
+		death = yes
+	}
+}
+
+190264 = {
+	name = "Hrodgaud"
+	dynasty = 1044052 #Munichingi
+	religion = catholic
+	culture = lombard
+	father = 190261
+	740.1.1 = {
+		birth = yes
+	}
+	776.1.1 = {
+		death = yes
+	}
+}
+
+190344 = {
+	name = "Gisaltruda" #wife of Aistulf king of Lombards
+	female = yes
+	dynasty = 1044052 #Munichingi
+	religion = catholic
+	culture = lombard
+	father = 190259
+	730.1.1 = {
+		birth = yes
+	}
+	781.1.1 = {
+		death = yes
+	}
+}
+
+190155 = {
+	name = "Falco"
+	dynasty = 1044042 #Falco
+	religion = catholic
+	culture = lombard
+	743.1.1 = {
+		birth = yes
+	}
+	764.1.1 = {
+		add_spouse = 190156
+	}
+	799.1.1 = {
+		death = yes
+	}
+}
+
+190156 = {
+	name = "Waldrada" #fictional
+	female = yes
+	dynasty = 1044043 #Walbertingi
+	religion = catholic
+	culture = lombard
+	747.1.1 = {
+		birth = yes
+	}
+	809.1.1 = {
+		death = yes
+	}
+}
+
+190157 = {
+	name = "Grimoald" #duke of Benevento
+	dynasty = 1044042 #Falco
+	religion = catholic
+	culture = lombard
+	father = 190155
+	mother = 190156
+	765.1.1 = {
+		birth = yes
+	}
+	817.1.1 = {
+		death = yes
+	}
+}
+
+190158 = {
+	name = "Sicard" #fictional
+	dynasty = 1044044 #Sicard
+	religion = catholic
+	culture = lombard
+	742.1.1 = {
+		birth = yes
+	}
+	758.1.1 = {
+		add_spouse = 190159
+	}
+	799.1.1 = {
+		death = yes
+	}
+}
+
+190159 = {
+	name = "Liutberga" #fictional
+	female = yes
+	dynasty = 1044085 #Liutprandling
+	religion = catholic
+	culture = lombard
+	740.1.1 = {
+		birth = yes
+	}
+	809.1.1 = {
+		death = yes
+	}
+}
+
+190160 = {
+	name = "Sico" #duke of Benevento
+	dynasty = 1044044 #Sicard
+	religion = catholic
+	culture = lombard
+	father = 190158
+	mother = 190159
+	758.1.1 = {
+		birth = yes
+	}
+	832.1.1 = {
+		death = yes
+	}
+}
+
+190161 = {
+	name = "Sicard" #duke of Benevento
+	dynasty = 1044044 #Sicard
+	religion = catholic
+	culture = lombard
+	father = 190160
+	779.1.1 = {
+		birth = yes
+	}
+	839.1.1 = {
+		death = yes
+	}
+}
+
+190162 = {
+	name = "Itta" #marries Guy I of Spoletto
+	female = yes
+	dynasty = 1044044 #Sicard
+	religion = catholic
+	culture = lombard
+	father = 190160
+	783.1.1 = {
+		birth = yes
+	}
+	840.1.1 = {
+		death = yes
+	}
+}
+
+190163 = {
+	name = "Siconulf" #duke of Salerno
+	dynasty = 1044044 #Sicard
+	religion = catholic
+	culture = lombard
+	father = 190160
+	789.1.1 = {
+		birth = yes
+	}
+	851.1.1 = {
+		death = yes
+	}
+}
+
+190164 = {
+	name = "Sico" #duke of Salerno
+	dynasty = 1044044 #Sicard
+	religion = catholic
+	culture = lombard
+	father = 190160
+	813.1.1 = {
+		birth = yes
+	}
+	855.1.1 = {
+		death = yes
+	}
+}
+
+190165 = {
+	name = "Masane" #marries Cleph king of Lombards
+	female = yes
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190122
+	mother = 190123
+	540.1.1 = {
+		birth = yes
+	}
+	592.1.1 = {
+		death = yes
+	}
+}
+
+190166 = {
+	name = "Rodelinda" #marries Zotto of Benevento
+	female = yes
+	dynasty = 1044031 #Gausian
+	religion = catholic
+	culture = lombard
+	father = 190122
+	mother = 190123
+	541.1.1 = {
+		birth = yes
+	}
+	590.1.1 = {
+		death = yes
+	}
+}
+
+190167 = {
+	name = "Beleo"
+	dynasty = 1044045 #Beleo
+	religion = catholic
+	culture = lombard
+	507.1.1 = {
+		birth = yes
+	}
+	557.1.1 = {
+		death = yes
+	}
+}
+
+190168 = {
+	name = "Cleph"
+	dynasty = 1044045 #Beleo
+	religion = catholic
+	culture = lombard
+	father = 190167
+	523.1.1 = {
+		birth = yes
+	}
+	556.1.1 = {
+		add_spouse = 190165
+	}
+	574.1.1 = {
+		death = yes
+	}
+}
+
+190169 = {
+	name = "Authari"
+	dynasty = 1044045 #Beleo
+	religion = catholic
+	culture = lombard
+	father = 190168
+	556.1.1 = {
+		birth = yes
+	}
+	584.1.1 = {
+		add_spouse = 190171
+	}
+	590.1.1 = {
+		remove_spouse = 190171
+	}
+	590.1.1 = {
+		death = yes
+	}
+}
+
+190170 = {
+	name = "Agilulf"
+	dynasty = 1044045 #Beleo
+	religion = catholic
+	culture = lombard
+	father = 190168
+	559.1.1 = {
+		birth = yes
+	}
+	590.1.1 = {
+		add_spouse = 190171
+	}
+	616.1.1 = {
+		death = yes
+	}
+}
+
+190172 = {
+	name = "Gundeberga" #wife of Arioald king of Lombards
+	female = yes
+	dynasty = 1044045 #Beleo
+	religion = catholic
+	culture = lombard
+	father = 190170
+	mother = 190171
+	598.1.1 = {
+		birth = yes
+	}
+	658.1.1 = {
+		death = yes
+	}
+}
+
+190173 = {
+	name = "Adaloald"
+	dynasty = 1044045 #Beleo
+	religion = catholic
+	culture = lombard
+	father = 190170
+	mother = 190171
+	602.1.1 = {
+		birth = yes
+	}
+	626.1.1 = {
+		death = yes
+	}
+}
+
+190174 = {
+	name = "Arioald"
+	dynasty = 1044047 #Arioaldling
+	religion = catholic
+	culture = lombard
+	578.1.1 = {
+		birth = yes
+	}
+	617.1.1 = {
+		add_spouse = 190172
+	}
+	636.1.1 = {
+		death = yes
+	}
+}
+
+190175 = {
+	name = "Nanding"
+	dynasty = 1044048 #Harodingian
+	religion = catholic
+	culture = lombard
+	572.1.1 = {
+		birth = yes
+	}
+	626.1.1 = {
+		death = yes
+	}
+}
+
+190176 = {
+	name = "Rothari"
+	dynasty = 1044048 #Harodingian
+	religion = catholic
+	culture = lombard
+	father = 190175
+	599.1.1 = {
+		birth = yes
+	}
+	652.1.1 = {
+		death = yes
+	}
+}
+
+190177 = {
+	name = "Rodoald"
+	dynasty = 1044048 #Harodingian
+	religion = catholic
+	culture = lombard
+	father = 190176
+	620.1.1 = {
+		birth = yes
+	}
+	653.1.1 = {
+		death = yes
+	}
+}
+
+190181 = {
+	name = "Aripert" #king of Lombards
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190180
+	609.1.1 = {
+		birth = yes
+	}
+	661.1.1 = {
+		death = yes
+	}
+}
+
+190182 = {
+	name = "Godepert" #king of Lombards
+	dynasty = 1044046 #Bavarae
+	religion = catholic #arian
+	culture = lombard
+	father = 190181
+	629.1.1 = {
+		birth = yes
+	}
+	662.1.1 = {
+		death = yes
+	}
+}
+
+190183 = {
+	name = "Raginpert" #king of Lombards
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190182
+	653.1.1 = {
+		birth = yes
+	}
+	701.6.1 = {
+		death = yes
+	}
+}
+
+190184 = {
+	name = "Aripert" #king of Lombards
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190183
+	672.1.1 = {
+		birth = yes
+	}
+	712.1.1 = {
+		death = yes
+	}
+}
+
+190185 = {
+	name = "Pectarit" #king of Lombards
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190181
+	637.1.1 = {
+		birth = yes
+	}
+	688.1.1 = {
+		death = yes
+	}
+}
+
+190186 = {
+	name = "Rodelinda"
+	female = yes
+	dynasty = 1044049 #Pandulfingi
+	religion = catholic
+	culture = lombard
+	640.1.1 = {
+		birth = yes
+	}
+	691.1.1 = {
+		death = yes
+	}
+}
+
+190187 = {
+	name = "Wigilinda" #marries Grimoald duke of Benevento
+	female = yes
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190185
+	mother = 190186
+	656.1.1 = {
+		birth = yes
+	}
+	690.1.1 = {
+		death = yes
+	}
+}
+
+190188 = {
+	name = "Cunipert" #king of Lombards
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190185
+	mother = 190186
+	659.1.1 = {
+		birth = yes
+	}
+	700.1.1 = {
+		death = yes
+	}
+}
+
+190189 = {
+	name = "Liutpert" #king of Lombards
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190188
+	689.1.1 = {
+		birth = yes
+	}
+	702.1.1 = {
+		death = yes
+	}
+}
+
+190190 = {
+	name = "Regintrude" #marries Theodo II of Bavaria
+	female = yes
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190182
+	657.1.1 = {
+		birth = yes
+	}
+	709.1.1 = {
+		death = yes
+	}
+}
+
+190191 = {
+	name = "Ratberg" #marries Pemmo son of Billo
+	female = yes
+	dynasty = 1044046 #Bavarae
+	religion = catholic
+	culture = lombard
+	father = 190184 #Aripert II of Lombardy
+	700.1.1 = {
+		birth = yes
+	}
+	742.1.1 = {
+		death = yes
+	}
+}
+
+190193 = {
+	name = "Ansprand"
+	dynasty = 1044051 #Ansprandling
+	religion = catholic
+	culture = lombard
+	652.1.1 = {
+		birth = yes
+	}
+	668.1.1 = {
+		add_spouse = 190192
+	}
+	712.1.1 = {
+		death = yes
+	}
+}
+
+190194 = {
+	name = "Sigibert"
+	dynasty = 1044051 #Ansprandling
+	religion = catholic
+	culture = lombard
+	father = 190193
+	mother = 190192
+	674.1.1 = {
+		birth = yes
+	}
+	712.1.1 = {
+		death = yes
+	}
+}
+
+190195 = {
+	name = "Aurona"
+	female = yes
+	dynasty = 1044051 #Ansprandling
+	religion = catholic
+	culture = lombard
+	father = 190193
+	mother = 190192
+	668.1.1 = {
+		birth = yes
+	}
+	712.1.1 = {
+		death = yes
+	}
+}
+
+190196 = {
+	name = "Liutprand"
+	dynasty = 1044051 #Ansprandling
+	religion = catholic
+	culture = lombard
+	father = 190193
+	mother = 190192
+	698.1.1 = {
+		birth = yes
+	}
+	714.1.1 = {
+		add_spouse = 190197
+	}
+	744.1.1 = {
+		death = yes
+	}
+}
+
+190198 = {
+	name = "Hildeprand"
+	dynasty = 1044051 #Ansprandling
+	religion = catholic
+	culture = lombard
+	father = 190194
+	710.1.1 = {
+		birth = yes
+	}
+	744.6.1 = {
+		death = yes
+	}
+}
+
+190199 = {
+	name = "Tasia" #maries Ratchis king of Lombards
+	female = yes
+	dynasty = 1044051 #Ansprandling
+	religion = catholic
+	culture = lombard
+	father = 190194
+	711.1.1 = {
+		birth = yes
+	}
+	770.1.1 = {
+		death = yes
+	}
+}
+
+190340 = {
+	name = "Ansia" #maries Desiderius king of Lombards
+	female = yes
+	dynasty = 1044051 #Ansprandling
+	religion = catholic
+	culture = lombard
+	father = 190194
+	712.1.1 = {
+		birth = yes
+	}
+	776.1.1 = {
+		death = yes
+	}
+}
+
+190341 = {
+	name = "Billo"
+	dynasty = 1044050 #Billoingi
+	religion = catholic
+	culture = lombard
+	658.1.1 = {
+		birth = yes
+	}
+	702.1.1 = {
+		death = yes
+	}
+}
+
+190342 = {
+	name = "Pemmo"
+	dynasty = 1044050 #Billoingi
+	religion = catholic
+	culture = lombard
+	father = 190341
+	687.1.1 = {
+		birth = yes
+	}
+	716.1.1 = {
+		add_spouse = 190191
+	}
+	739.1.1 = {
+		death = yes
+	}
+}
+
+190343 = {
+	name = "Ratchis" #king of Lombards
+	dynasty = 1044050 #Billoingi
+	religion = catholic
+	culture = lombard
+	father = 190342
+	mother = 190191
+	716.1.1 = {
+		birth = yes
+	}
+	732.1.1 = {
+		add_spouse = 190199
+	}
+	758.1.1 = {
+		death = yes
+	}
+}
+
+190331 = {
+	name = "Aistulf" #king of Lombards
+	dynasty = 1044050 #Billoingi
+	religion = catholic
+	culture = lombard
+	father = 190342
+	mother = 190191
+	717.1.1 = {
+		birth = yes
+	}
+	749.1.1 = {
+		add_spouse = 190344
+	}
+	756.1.1 = {
+		death = yes
+	}
+}
+
+190345 = {
+	name = "Alahis"
+	dynasty = 1044053 #Alachislings
+
+	religion = catholic
+	culture = lombard
+
+	685.1.1 = {
+		birth = yes
+	}
+
+	726.1.1 = {
+		death = yes
+	}
+}
+
+190346 = {
+	name = "Erminolf"
+	dynasty = 1044053 #Alachislings
+
+	father = 190345
+
+	religion = catholic
+	culture = lombard
+
+	701.1.1 = {
+		birth = yes
+	}
+	756.1.1 = {
+		death = yes
+	}
+}
+
+190347 = {
+	name = "Desiderius" #Desiderius, King of Lombards - Daufer
+	dynasty = 1044053 #Alachislings
+	dna = aldccxlhgaf
+	properties = ai0afa000000
+
+	father = 190346
+
+	religion = catholic
+	culture = lombard
+
+	717.1.1 = {
+		birth = yes
+	}
+	734.1.1 = {
+		add_spouse = 190340
+	}
+	786.1.1 = {
+		death = yes
+	}
+}
+
+190348 = {
+	name = "Gerberga" #marries Carloman of France
+	female = yes
+	dynasty = 1044053 #Alachislings
+	religion = catholic
+	culture = lombard
+	father = 190347
+	mother = 190340
+	745.1.1 = {
+		birth = yes
+	}
+	794.1.1 = {
+		death = yes
+	}
+}
+
+190349 = {
+	name = "Dauferada" #marries Charlemagne
+	female = yes
+	dynasty = 1044053 #Alachislings
+
+	father = 190347
+	mother = 190340
+
+	religion = catholic
+	culture = lombard
+
+	747.1.1 = {
+		birth = yes
+	}
+	796.1.1 = {
+		death = yes
+	}
+}
+
+190351 = {
+	name = "Liutperga" #marries Tassilo IV of Bavaria
+	female = yes
+	dynasty = 1044053 #Alachislings
+	religion = catholic
+	culture = lombard
+	father = 190347
+	mother = 190340
+	750.1.1 = {
+		birth = yes
+	}
+	794.1.1 = {
+		death = yes
+	}
+}
+
+190352 = {
+	name = "Anselperga"
+	female = yes
+	dynasty = 1044053 #Alachislings
+	religion = catholic
+	culture = lombard
+	father = 190347
+	mother = 190340
+	744.1.1 = {
+		birth = yes
+	}
+	794.1.1 = {
+		death = yes
+	}
+}
+
+190353 = {
+	name = "Adelchis"
+	dynasty = 1044053 #Alachislings
+	religion = catholic
+	culture = lombard
+	father = 190347
+	mother = 190340
+	759.1.1 = {
+		birth = yes
+	}
+	788.1.1 = {
+		death = yes
+	}
+}
+
+190354 = {
+	name = "Alahis" #king of Lombards
+	dynasty = 1044054 #Sicardling
+	religion = catholic
+	culture = lombard
+	654.1.1 = {
+		birth = yes
+	}
+	689.1.1 = {
+		death = yes
+	}
+}
+
+190265 = {
+	name = "Theodicus" #duke of Spoleto
+	dynasty = 1044061 #Theodingi
+	religion = catholic
+	culture = lombard
+	727.1.1 = {
+		birth = yes
+	}
+	747.1.1 = {
+		add_spouse = 190266
+	}
+	776.1.1 = {
+		death = yes
+	}
+}
+
+190266 = {
+	name = "Giselberga" #wife of Theodicus
+	female = yes
+	dynasty = 1044062 #Giselbertingi
+	religion = catholic
+	culture = lombard
+	731.1.1 = {
+		birth = yes
+	}
+	780.6.1 = {
+		death = yes
+	}
+}
+
+190267 = {
+	name = "Hildeprand" #duke of Spoleto
+	dynasty = 1044061 #Theodingi
+	religion = catholic
+	culture = lombard
+	father = 190265
+	mother = 190266
+	750.1.1 = {
+		birth = yes
+	}
+	789.1.1 = {
+		death = yes
+	}
+}
+
+190268 = {
+	name = "Ursus" #count of Bologna (Persiceta)
+	dynasty = 1044063 #Ursingi
+	religion = catholic
+	culture = lombard
+	721.1.1 = {
+		birth = yes
+	}
+	772.1.1 = {
+		death = yes
+	}
+}
+
+190269 = {
+	name = "John" #count of Bologna
+	dynasty = 1044063 #Ursingi
+	religion = catholic
+	culture = lombard
+	father = 190268
+	740.1.1 = {
+		birth = yes
+	}
+	776.1.1 = {
+		death = yes
+	}
+}
+
+190270 = {
+	name = "Ursus" #count of Bologna
+	dynasty = 1044063 #Ursingi
+	religion = catholic
+	culture = lombard
+	father = 190269
+	760.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+190271 = {
+	name = "Ademaro" #count of Verona
+	dynasty = 1044064 #Ademingi
+	religion = catholic
+	culture = lombard
+	701.1.1 = {
+		birth = yes
+	}
+	768.1.1 = {
+		death = yes
+	}
+}
+
+190272 = {
+	name = "Ademaro" #count of Verona
+	dynasty = 1044064 #Ademingi
+	religion = catholic
+	culture = lombard
+	father = 190271
+	742.1.1 = {
+		birth = yes
+	}
+	809.1.1 = {
+		death = yes
+	}
+}
+
+190273 = {
+	name = "Brunhilda" #wife of Ursus of Bologna
+	female = yes
+	dynasty = 1044064 #Ademingi
+	religion = catholic
+	culture = lombard
+	father = 190269
+	756.1.1 = { #postponed from 743
+		birth = yes
+	}
+	802.1.1 = {
+		death = yes
+	}
+}
+
+190274 = {
+	name = "Adalbert" #count of Genoa
+	dynasty = 1044065 #Adalbertingi
+	religion = catholic
+	culture = lombard
+	725.1.1 = {
+		birth = yes
+	}
+	762.1.1 = {
+		death = yes
+	}
+}
+
+190275 = {
+	name = "Ademaro" #count of Genoa
+	dynasty = 1044065 #Adalbertingi
+	religion = catholic
+	culture = lombard
+	father = 190274
+	742.1.1 = {
+		birth = yes
+	}
+	806.1.1 = {
+		death = yes
+	}
+}
+
+190276 = {
+	name = "Adalberga" #wife of Alperto of Tuscany
+	female = yes
+	dynasty = 1044065 #Adalbertingi
+	religion = catholic
+	culture = lombard
+	father = 190274
+	744.1.1 = {
+		birth = yes
+	}
+	816.1.1 = {
+		death = yes
+	}
+}
+
+190277 = {
+	name = "Peter" #count of Corsica
+	dynasty = 1044065 #Adalbertingi
+	religion = catholic
+	culture = lombard
+	father = 190274
+	747.1.1 = {
+		birth = yes
+	}
+	806.1.1 = {
+		death = yes
+	}
+}
+
+190278 = {
+	name = "Walperto" #duke of Tuscany
+	dynasty = 1044066 #Walpertingi
+	religion = catholic
+	culture = lombard
+	702.1.1 = {
+		birth = yes
+	}
+	754.1.1 = {
+		death = yes
+	}
+}
+
+190279 = {
+	name = "Alperto" #duke of Tuscany
+	dynasty = 1044066 #Walpertingi
+	religion = catholic
+	culture = lombard
+	father = 190278
+	722.1.1 = {
+		birth = yes
+	}
+	760.1.1 = {
+		add_spouse = 190276
+	}
+	773.1.1 = {
+		death = yes
+	}
+}
+
+190280 = {
+	name = "Tachiperto" #duke of Tuscany
+	dynasty = 1044066 #Walpertingi
+	religion = catholic
+	culture = lombard
+	father = 190278
+	743.1.1 = {
+		birth = yes
+	}
+	774.1.1 = {
+		death = yes
+	}
+}
+
+190281 = {
+	name = "Tachiperga" #wife of Teuderic count of Ravenna
+	female = yes
+	dynasty = 1044066 #Walpertingi
+	religion = catholic
+	culture = lombard
+	father = 190278
+	745.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+190282 = {
+	name = "Lupo" #count of Ferrara
+	dynasty = 1044066 #Walpertingi
+	religion = catholic
+	culture = lombard
+	father = 190278
+	727.1.1 = {
+		birth = yes
+	}
+	770.1.1 = {
+		death = yes
+	}
+}
+
+190283 = {
+	name = "Tachiperto" #count of Ancona and Urbino
+	dynasty = 1044067 #Tachipertingi
+	religion = catholic
+	culture = lombard
+	721.1.1 = {
+		birth = yes
+	}
+	760.1.1 = {
+		death = yes
+	}
+}
+
+190284 = {
+	name = "Lupo" #count of Ancona
+	dynasty = 1044067 #Tachipertingi
+	religion = catholic
+	culture = lombard
+	father = 190283
+	741.1.1 = {
+		birth = yes
+	}
+	778.1.1 = {
+		death = yes
+	}
+}
+
+190285 = {
+	name = "Halo" #count of Urbino
+	dynasty = 1044067 #Tachipertingi
+	religion = catholic
+	culture = lombard
+	father = 190283
+	747.1.1 = {
+		birth = yes
+	}
+	784.1.1 = {
+		death = yes
+	}
+}
+
+190286 = {
+	name = "Hilciperga" #wife of Hilderic of Ravenna
+	female = yes
+	dynasty = 1044067 #Tachipertingi
+	religion = catholic
+	culture = lombard
+	father = 190283
+	753.1.1 = {
+		birth = yes
+	}
+	799.1.1 = {
+		death = yes
+	}
+}
+
+190287 = {
+	name = "Teuderic" #count of Ravenna
+	dynasty = 1044068 #Teudericingi
+	religion = catholic
+	culture = lombard
+	743.1.1 = {
+		birth = yes
+	}
+	761.1.1 = {
+		add_spouse = 190281
+	}
+	776.1.1 = {
+		death = yes
+	}
+}
+
+190288 = {
+	name = "Hilderic" #count of Ravenna
+	dynasty = 1044068 #Teudericingi
+	religion = catholic
+	culture = lombard
+	father = 190287
+	mother = 190281
+	761.1.1 = {
+		birth = yes
+	}
+	779.1.1 = {
+		add_spouse = 190286
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+190289 = {
+	name = "Daufer" #count of Salerno
+	dynasty = 1044069 #Daufingi
+	religion = catholic
+	culture = lombard
+	743.1.1 = {
+		birth = yes
+	}
+	818.1.1 = {
+		death = yes
+	}
+}
+
+190290 = {
+	name = "Rotfrit" #count of Salerno
+	dynasty = 1044069 #Daufingi
+	religion = catholic
+	culture = lombard
+	father = 190289
+	776.1.1 = {
+		birth = yes
+	}
+	836.1.1 = {
+		death = yes
+	}
+}
+
+190291 = {
+	name = "Adelchis" #count of Salerno
+	dynasty = 1044069 #Daufingi
+	religion = catholic
+	culture = lombard
+	father = 190290
+	796.1.1 = {
+		birth = yes
+	}
+	839.1.1 = {
+		death = yes
+	}
+}
+
+190292 = {
+	name = "Rotfreda" #wife of Landolf I of Capua
+	female = yes
+	dynasty = 1044069 #Daufingi
+	religion = catholic
+	culture = lombard
+	father = 190290
+	797.1.1 = {
+		birth = yes
+	}
+	860.1.1 = {
+		death = yes
+	}
+}
+
+190293 = {
+	name = "Potelfrit"
+	dynasty = 1044069 #Daufingi
+	religion = catholic
+	culture = lombard
+	father = 190289
+	778.1.1 = {
+		birth = yes
+	}
+	818.1.1 = {
+		death = yes
+	}
+}
+
+190294 = {
+	name = "Potelfreda" #wife of Landendolf II of Capua
+	female = yes
+	dynasty = 1044069 #Daufingi
+	religion = catholic
+	culture = lombard
+	father = 190293
+	804.1.1 = {
+		birth = yes
+	}
+	862.1.1 = {
+		death = yes
+	}
+}
+
+190295 = {
+	name = "Rodoald" #count of Consenza
+	dynasty = 1044070 #Rodoingi
+	religion = catholic
+	culture = lombard
+	723.1.1 = {
+		birth = yes
+	}
+	766.1.1 = {
+		death = yes
+	}
+}
+
+190296 = {
+	name = "Radulhin" #count of Consenza
+	dynasty = 1044070 #Rodoingi
+	religion = catholic
+	culture = lombard
+	father = 190295
+	740.1.1 = {
+		birth = yes
+	}
+	788.1.1 = {
+		death = yes
+	}
+}
+
+190297 = {
+	name = "Ermepert" #count of Constanza
+	dynasty = 1044070 #Rodoingi
+	religion = catholic
+	culture = lombard
+	father = 190295
+	743.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+190298 = {
+	name = "Eufemia" #wife of Roderissus of Taranto
+	female = yes
+	dynasty = 1044070 #Rodoingi
+	religion = catholic
+	culture = lombard
+	father = 190295
+	742.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+190299 = {
+	name = "Roderissus" #count of Taranto
+	dynasty = 1044086 #Roderissingi
+	religion = catholic
+	culture = lombard
+	745.1.1 = {
+		birth = yes
+	}
+	762.1.1 = {
+		add_spouse = 190298
+	}
+	810.1.1 = {
+		death = yes
+	}
+}
+
+190300 = {
+	name = "Rodegar" #count of Taranto
+	dynasty = 1044086 #Roderissingi
+	religion = catholic
+	culture = lombard
+	father = 190299
+	mother = 190298
+	763.1.1 = {
+		birth = yes
+	}
+	811.1.1 = {
+		death = yes
+	}
+}
+
+190301 = {
+	name = "Roderissus" #count of Taranto
+	dynasty = 1044086 #Roderissingi
+	religion = catholic
+	culture = lombard
+	father = 190300
+	783.1.1 = {
+		birth = yes
+	}
+	814.1.1 = {
+		death = yes
+	}
+}
+
+190302 = {
+	name = "Framicus"
+	dynasty = 1044086 #Roderissingi
+	religion = catholic
+	culture = lombard
+	father = 190299
+	mother = 190298
+	765.1.1 = {
+		birth = yes
+	}
+	810.1.1 = {
+		death = yes
+	}
+}
+
+190303 = {
+	name = "Gandulf" #count of Bari
+	dynasty = 1044071 #Gandulfingi
+	religion = catholic
+	culture = lombard
+	721.1.1 = {
+		birth = yes
+	}
+	766.1.1 = {
+		death = yes
+	}
+}
+
+190304 = {
+	name = "Daufer" #count of Bari
+	dynasty = 1044071 #Gandulfingi
+	religion = catholic
+	culture = lombard
+	father = 190303
+	763.1.1 = {
+		birth = yes
+	}
+	830.1.1 = {
+		death = yes
+	}
+}
+
+190305 = {
+	name = "Rodegar" #count of Bari
+	dynasty = 1044071 #Gandulfingi
+	religion = catholic
+	culture = lombard
+	father = 190304
+	789.1.1 = {
+		birth = yes
+	}
+	834.1.1 = {
+		death = yes
+	}
+}
+
+190306 = {
+	name = "Arnegisa" #wife of Maio of Aprutium
+	female = yes
+	dynasty = 1044071 #Gandulfingi
+	religion = catholic
+	culture = lombard
+	father = 190303
+	741.1.1 = {
+		birth = yes
+	}
+	811.1.1 = {
+		death = yes
+	}
+}
+
+190307 = {
+	name = "Radegisa" #wife of Paldo of Apulia
+	female = yes
+	dynasty = 1044071 #Gandulfingi
+	religion = catholic
+	culture = lombard
+	father = 190303
+	743.1.1 = {
+		birth = yes
+	}
+	810.1.1 = {
+		death = yes
+	}
+}
+
+190308 = {
+	name = "Maio" #count of Aprutium
+	dynasty = 1044072 #Maioingi
+	religion = catholic
+	culture = lombard
+	742.1.1 = {
+		birth = yes
+	}
+	762.1.1 = {
+		add_spouse = 190306
+	}
+	813.1.1 = {
+		death = yes
+	}
+}
+
+190309 = {
+	name = "Maio" #count of Aprutium
+	dynasty = 1044072 #Maioingi
+	religion = catholic
+	culture = lombard
+	father = 190308
+	mother = 190306
+	766.1.1 = {
+		birth = yes
+	}
+	850.1.1 = {
+		death = yes
+	}
+}
+
+190310 = {
+	name = "Paldo" #count of Apulia
+	dynasty = 1044073 #Paldingi
+	religion = catholic
+	culture = lombard
+	746.1.1 = {
+		birth = yes
+	}
+	762.1.1 = {
+		add_spouse = 190307
+	}
+	807.1.1 = {
+		death = yes
+	}
+}
+
+190311 = {
+	name = "Stefano" #count of Apulia
+	dynasty = 1044073 #Paldingi
+	religion = catholic
+	culture = lombard
+	father = 190310
+	mother = 190307
+	766.1.1 = {
+		birth = yes
+	}
+	827.1.1 = {
+		death = yes
+	}
+}
+
+190312 = {
+	name = "Varbert" #count of Mantua
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	736.1.1 = {
+		birth = yes
+	}
+	753.1.1 = {
+		add_spouse = 190313
+	}
+	797.1.1 = {
+		death = yes
+	}
+}
+
+190313 = {
+	name = "Richildis" #wife of Varbert of Mantua
+	female = yes
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	735.1.1 = {
+		birth = yes
+	}
+	797.1.1 = {
+		death = yes
+	}
+}
+
+190314 = {
+	name = "Lambert" #count of Parma
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	father = 190312
+	mother = 190313
+	753.1.1 = {
+		birth = yes
+	}
+	817.1.1 = {
+		death = yes
+	}
+}
+
+190315 = {
+	name = "Grimauld"
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	father = 190312
+	mother = 190313
+	755.1.1 = {
+		birth = yes
+	}
+	817.1.1 = {
+		death = yes
+	}
+}
+
+190316 = {
+	name = "Varberga"
+	female = yes
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	father = 190312
+	mother = 190313
+	757.1.1 = {
+		birth = yes
+	}
+	820.1.1 = {
+		death = yes
+	}
+}
+
+190317 = {
+	name = "Billo"
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	father = 190312
+	mother = 190313
+	758.1.1 = {
+		birth = yes
+	}
+	818.1.1 = {
+		death = yes
+	}
+}
+
+190318 = {
+	name = "Drogo"
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	father = 190312
+	mother = 190313
+	759.1.1 = {
+		birth = yes
+	}
+	818.1.1 = {
+		death = yes
+	}
+}
+
+190319 = {
+	name = "Daufer"
+	dynasty = 1044074 #Varbertingi
+	religion = catholic
+	culture = lombard
+	father = 190312
+	mother = 190313
+	763.1.1 = {
+		birth = yes
+	}
+	827.1.1 = {
+		death = yes
+	}
+}
+
+190320 = {
+	name = "Paldo" #count of Milan
+	dynasty = 1044075 #Paldoling
+	religion = catholic
+	culture = lombard
+	746.1.1 = {
+		birth = yes
+	}
+	807.1.1 = {
+		death = yes
+	}
+}
+
+190321 = {
+	name = "Tato" #count of Trent
+	dynasty = 1044076 #Tatingi
+	religion = catholic
+	culture = lombard
+	746.1.1 = {
+		birth = yes
+	}
+	802.1.1 = {
+		death = yes
+	}
+}
+
+190322 = {
+	name = "Lambert" #count of Modena
+	dynasty = 1044077 #Lambertingi
+	religion = catholic
+	culture = lombard
+	741.1.1 = {
+		birth = yes
+	}
+	809.1.1 = {
+		death = yes
+	}
+}
+
+190323 = {
+	name = "Engelbert" #count of Treviso
+	dynasty = 1044078 #Engelbertingi
+	religion = catholic
+	culture = lombard
+	742.1.1 = {
+		birth = yes
+	}
+	807.1.1 = {
+		death = yes
+	}
+}
+
+190324 = {
+	name = "Liutfred" #count of Montferrat
+	dynasty = 1044079 #Liutfredingi
+	religion = catholic
+	culture = lombard
+	737.1.1 = {
+		birth = yes
+	}
+	778.1.1 = {
+		death = yes
+	}
+}
+
+190325 = {
+	name = "Gaidoald" #count of Brescia
+	dynasty = 1044080 #Gaidolaldingi
+	religion = catholic
+	culture = lombard
+	740.1.1 = {
+		birth = yes
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+190326 = {
+	name = "Taso" #count of Sienna
+	dynasty = 1044081 #Tasingi
+	religion = catholic
+	culture = lombard
+	746.1.1 = {
+		birth = yes
+	}
+	804.1.1 = {
+		death = yes
+	}
+}
+
+190328 = {
+	name = "Peter" #count of Orvieto/Orbetello
+	dynasty = 1044082 #Petringi
+	religion = catholic
+	culture = lombard
+	737.1.1 = {
+		birth = yes
+	}
+	804.1.1 = {
+		death = yes
+	}
+}
+
+190329 = {
+	name = "Faroald" #count of Piombino
+	dynasty = 1044083 #Faroaldingi
+	religion = catholic
+	culture = lombard
+	751.1.1 = {
+		birth = yes
+	}
+	799.1.1 = {
+		death = yes
+	}
+}
+
+190330 = {
+	name = "Liutprand" #duke of Susa
+	dynasty = 1044084 #Liutprandingi
+	religion = catholic
+	culture = lombard
+	740.1.1 = {
+			birth = yes
+	}
+	791.1.1 = {
+		death = yes
+	}
+}
+
+190332 = {
+	name = "Pando" #count of Capua
+	dynasty = 7184 #di Capua
+	religion = catholic
+	culture = lombard
+	740.1.1 = {
+		birth = yes
+	}
+	815.1.1 = {
+		death = yes
+	}
+}
+
+30854 = {
+	name = "Gemma"
+	female = yes
+	dynasty = 7184
+
+	father = 73354
+
+	religion = catholic
+	culture = lombard
+
+	1018.1.1 = {
+		birth = yes
+	}
+	1070.12.1 = {
+		death = yes
+	}
+}
+
+73317 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73318
+	mother = 73320
+
+	religion = catholic
+	culture = lombard
+
+	1040.1.1 = {
+		birth = yes
+	}
+	1068.1.1 = {
+		add_spouse = 73319
+	}
+	1073.2.1 = {
+		death = yes
+	}
+}
+
+73318 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73321
+	mother = 73322
+
+	religion = catholic
+	culture = lombard
+
+	1017.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		add_spouse = 73320
+	}
+	1077.12.18 = {
+		death = yes
+	}
+}
+
+73319 = {
+	name = "Altruda"
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1050.1.1 = {
+		birth = yes
+	}
+	1119.7.7 = {
+		death = yes
+	}
+}
+
+73320 = {
+	name = "Maria"
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1020.1.1 = {
+		birth = yes
+	}
+	1069.5.20 = {
+		death = yes
+	}
+}
+
+73321 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73323
+	mother = 168453
+
+	religion = catholic
+	culture = lombard
+
+	995.1.1 = {
+		birth = yes
+	}
+	1016.1.1 = {
+		add_spouse = 73322
+	}
+	1059.1.1 = {
+		death = yes
+	}
+}
+
+73322 = {
+	name = "Altruda"
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1000.1.1 = {
+		birth = yes
+	}
+	1069.5.20 = {
+		death = yes
+	}
+}
+
+73323 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73324
+
+	religion = catholic
+	culture = lombard
+
+	978.1.1 = {
+		birth = yes
+	}
+	994.1.1 = {
+		add_spouse = 168453
+	}
+	1034.9.1 = {
+		death = yes
+	}
+}
+
+73324 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73325
+
+	religion = catholic
+	culture = lombard
+
+	953.1.1 = {
+		birth = yes
+	}
+	1014.8.1 = {
+		death = yes
+	}
+}
+
+73325 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73328
+
+	religion = catholic
+	culture = lombard
+
+	930.1.1 = {
+		birth = yes
+	}
+	968.1.1 = {
+		death = yes
+	}
+}
+
+73326 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73327
+
+	religion = catholic
+	culture = lombard
+
+	950.1.1 = {
+		birth = yes
+	}
+	982.7.13 = {
+		death = yes
+	}
+}
+
+73327 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73328
+
+	religion = catholic
+	culture = lombard
+
+	927.1.1 = {
+		birth = yes
+	}
+	981.3.1 = {
+		death = yes
+	}
+}
+
+73328 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73330
+	mother = 262249
+
+	religion = catholic
+	culture = lombard
+
+	902.1.1 = {
+		birth = yes
+	}
+	961.1.1 = {
+		death = yes
+	}
+}
+
+73329 = {
+	name = "Atenolf"
+	dynasty = 7184
+
+	father = 73330
+	mother = 262249
+
+	religion = catholic
+	culture = lombard
+
+	900.1.1 = {
+		birth = yes
+	}
+	943.1.1 = {
+		death = yes
+	}
+}
+
+73330 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73331
+
+	religion = catholic
+	culture = lombard
+
+	872.1.1 = {
+		birth = yes
+	}
+	943.1.1 = {
+		death = yes
+	}
+}
+
+73331 = {
+	name = "Atenolf"
+	dynasty = 7184
+
+	religion = catholic
+	culture = lombard
+
+	father = 163072
+
+	847.1.1 = {
+		birth = yes
+	}
+	912.1.1 = {
+		death = yes
+	}
+}
+
+73332 = {
+	name = "Atenolf"
+	dynasty = 7184
+
+	religion = catholic
+	culture = lombard
+
+	father = 73331
+
+	874.1.1 = {
+		birth = yes
+	}
+	941.1.1 = {
+		death = yes
+	}
+}
+
+73333 = {
+	name = "Landenolf"
+	dynasty = 7184
+
+	father = 73327
+
+	religion = catholic
+	culture = lombard
+
+	956.1.1 = {
+		birth = yes
+	}
+	993.4.21 = {
+		death = yes
+	}
+}
+
+73334 = {
+	name = "Laidolf"
+	dynasty = 7184
+
+	father = 73327
+
+	religion = catholic
+	culture = lombard
+
+	957.1.1 = {
+		birth = yes
+	}
+	1015.1.1 = {
+		death = yes
+	}
+}
+
+73335 = {
+	name = "Ademar"
+
+	religion = catholic
+	culture = lombard
+
+	956.1.1 = {
+		birth = yes
+	}
+	1009.3.1 = {
+		death = yes
+	}
+}
+
+73336 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73325
+
+	religion = catholic
+	culture = lombard
+
+	952.1.1 = {
+		birth = yes
+	}
+	1007.1.1 = {
+		death = yes
+	}
+}
+
+73337 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73336
+
+	religion = catholic
+	culture = lombard
+
+	976.1.1 = {
+		birth = yes
+	}
+	1022.1.1 = {
+		death = yes
+	}
+}
+
+73338 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73324
+
+	religion = catholic
+	culture = lombard
+
+	977.1.1 = {
+		birth = yes
+	}
+	1049.2.20 = {
+		death = yes
+	}
+}
+
+73339 = {
+	name = "Gisulf"
+	dynasty = 7184
+
+	father = 73327
+
+	religion = catholic
+	culture = lombard
+
+	959.1.1 = {
+		birth = yes
+	}
+	996.8.1 = {
+		death = yes
+	}
+}
+
+73340 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73339
+
+	religion = catholic
+	culture = lombard
+
+	982.1.1 = {
+		birth = yes
+	}
+	1026.1.1 = {
+		death = yes
+	}
+}
+
+73341 = {
+	name = "Ioannes"
+	dynasty = 7184
+
+	father = 73340
+
+	religion = catholic
+	culture = lombard
+
+	1005.1.1 = {
+		birth = yes
+	}
+	1047.1.1 = {
+		death = yes
+	}
+}
+
+73342 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73338
+
+	religion = catholic
+	culture = lombard
+
+	1000.1.1 = {
+		birth = yes
+	}
+	1057.1.1 = {
+		death = yes
+	}
+}
+
+73343 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 73342
+
+	religion = catholic
+	culture = lombard
+
+	1022.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+73344 = {
+	name = "Sichelgaita"
+	female = yes
+	dynasty = 7184
+
+	father = 73343
+
+	religion = catholic
+	culture = lombard
+
+	1041.1.1 = {
+		birth = yes
+	}
+	1098.1.1 = {
+		death = yes
+	}
+}
+
+73345 = {
+	name = "Adelgrima"
+	female = yes
+	dynasty = 7184
+
+	father = 73342
+
+	religion = catholic
+	culture = lombard
+
+	1023.1.1 = {
+		birth = yes
+	}
+	1105.1.1 = {
+		death = yes
+	}
+}
+
+73346 = {
+	name = "Lando"
+	dynasty = 12243
+
+	religion = catholic
+	culture = lombard
+
+	1018.1.1 = {
+		birth = yes
+	}
+	1041.1.1 = {
+		add_spouse = 73345
+	}
+	1065.1.1 = {
+		death = yes
+	}
+}
+
+73347 = {
+	name = "Atenolf"
+	dynasty = 12243
+
+	father = 73346
+	mother = 73345
+
+	religion = catholic
+	culture = lombard
+
+	1042.1.1 = {
+		birth = yes
+	}
+	1105.1.1 = {
+		death = yes
+	}
+}
+
+73348 = {
+	name = "Landolf"
+	dynasty = 12243
+
+	father = 73346
+	mother = 73345
+
+	religion = catholic
+	culture = lombard
+
+	1043.1.1 = {
+		birth = yes
+	}
+	1107.1.1 = {
+		death = yes
+	}
+}
+
+73349 = {
+	name = "Pandolf"
+	dynasty = 12243
+
+	father = 73346
+	mother = 73345
+
+	religion = catholic
+	culture = lombard
+
+	1045.1.1 = {
+		birth = yes
+	}
+	1108.1.1 = {
+		death = yes
+	}
+}
+
+73350 = {
+	name = "Lando"
+	dynasty = 12243
+
+	father = 73346
+	mother = 73345
+
+	religion = catholic
+	culture = lombard
+
+	1046.1.1 = {
+		birth = yes
+	}
+	1098.1.1 = {
+		death = yes
+	}
+}
+
+73351 = {
+	name = "Atenolf"
+	dynasty = 12243
+
+	father = 73347
+
+	religion = catholic
+	culture = lombard
+
+	1066.1.1 = {
+		birth = yes
+	}
+	1118.1.1 = {
+		death = yes
+	}
+}
+
+73352 = {
+	name = "Sichelgaita"
+	female = yes
+	dynasty = 12243
+
+	father = 73347
+
+	religion = catholic
+	culture = lombard
+
+	1068.1.1 = {
+		birth = yes
+	}
+	1125.1.1 = {
+		death = yes
+	}
+}
+
+73353 = {
+	name = "Petrus"
+	dynasty = 12243
+
+	father = 73350
+
+	religion = catholic
+	culture = lombard
+
+	1070.1.1 = {
+		birth = yes
+	}
+	1127.1.1 = {
+		death = yes
+	}
+}
+
+73354 = {
+	name = "Laidolf"
+	dynasty = 7184
+
+	father = 73338
+
+	religion = catholic
+	culture = lombard
+
+	1002.1.1 = {
+		birth = yes
+	}
+	1046.2.1 = {
+		death = yes
+	}
+}
+
+73355 = {
+	name = "Pandolf"
+	dynasty = 7184
+
+	father = 73354
+
+	religion = catholic
+	culture = lombard
+
+	1022.1.1 = {
+		birth = yes
+	}
+	1052.8.1 = {
+		death = yes
+	}
+}
+
+2012 = {
+	name = "Daufer"
+	dynasty = 7184
+
+	father = 73323
+
+	religion = catholic
+	culture = lombard
+
+	trait = humble
+	trait = zealous
+	trait = scholarly_theologian
+
+	1026.1.1 = {
+		birth = yes
+	}
+	1085.5.25 = {
+		name = "Victor"
+	}
+	1087.9.16 = {
+		death = yes
+	}
+}
+
+163072 = {
+	name = "Landenolf"
+	dynasty = 7184
+
+	father = 163075
+	mother = 190292
+
+	religion = catholic
+	culture = lombard
+
+	810.1.1 = {
+		birth = yes
+	}
+	859.1.1 = {
+		death = yes
+	}
+}
+
+163073 = {
+	name = "Landenolf"
+	dynasty = 7184
+
+	father = 163072
+	mother = 190294
+
+	religion = catholic
+	culture = lombard
+
+	846.1.1 = {
+		birth = yes
+	}
+	887.1.1 = {
+		death = yes
+	}
+}
+
+163074 = {
+	name = "Lando"
+	dynasty = 7184
+
+	father = 163072
+	mother = 190294
+
+	religion = catholic
+	culture = lombard
+
+	845.1.1 = {
+		birth = yes
+	}
+	885.1.1 = {
+		death = yes
+	}
+}
+
+163075 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 190332
+
+	religion = catholic
+	culture = lombard
+
+	780.1.1 = {
+		birth = yes
+	}
+	798.1.1 = {
+		add_spouse = 190292
+	}
+	843.1.1 = {
+		death = yes
+	}
+}
+
+163076 = {
+	name = "Lando"
+	dynasty = 7184
+
+	father = 163075
+	mother = 190292
+
+	religion = catholic
+	culture = lombard
+
+	798.1.1 = {
+		birth = yes
+	}
+	861.1.1 = {
+		death = yes
+	}
+}
+
+163077 = {
+	name = "Pando"
+	dynasty = 7184
+
+	father = 163075
+	mother = 190292
+
+	religion = catholic
+	culture = lombard
+
+	799.1.1 = {
+		birth = yes
+	}
+	862.1.1 = {
+		death = yes
+	}
+}
+
+163078 = {
+	name = "Pandenolf"
+	dynasty = 7184
+
+	father = 163077
+
+	religion = catholic
+	culture = lombard
+
+	830.1.1 = {
+		birth = yes
+	}
+	882.1.1 = {
+		death = yes
+	}
+}
+
+163079 = {
+	name = "Landolf"
+	dynasty = 7184
+
+	father = 163075
+	mother = 190292
+
+	religion = catholic
+	culture = lombard
+
+	825.1.1 = {
+		birth = yes
+	}
+	879.1.1 = {
+		death = yes
+	}
+}
+
+168496 = {
+	name = "Maria"
+	female = yes
+	dynasty = 7184
+
+	father = 73324
+
+	religion = catholic
+	culture = lombard
+
+	980.1.1 = {
+		birth = yes
+	}
+	1040.1.1 = {
+		death = yes
+	}
+}
+
+145206 = {
+	name = "Lando"
+	dynasty = 7184
+
+	father = 163076
+
+	religion = catholic
+	culture = lombard
+
+	820.1.1 = {
+		birth = yes
+	}
+	866.1.1 = {
+		death = yes
+	}
+}
+
+1116 = {
+	name = "Guaimar"
+	dynasty = 100336
+
+	father = 30857
+
+	religion = catholic
+	culture = lombard
+
+	1010.1.1 = {
+		birth = yes
+	}
+	1026.1.1 = {
+		add_spouse = 1117
+	}
+	1032.5.1 = {
+		add_spouse = 30854
+	}
+	1052.6.3 = {
+		death = yes
+	}
+}
+
+1117 = {
+	name = "Purpura"
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1010.1.1 = {
+		birth = yes
+	}
+	1032.1.1 = {
+		death = yes
+	}
+}
+
+1119 = {
+	name = "Gisulf"
+	dynasty = 100336
+
+	father = 1116
+	mother = 30854
+
+	religion = catholic
+	culture = lombard
+
+	1035.1.1 = {
+		birth = yes
+	}
+	1091.1.2 = {
+		death = yes
+	}
+}
+
+1123 = {
+	name = "Sichelgaita"
+	female = yes
+	dynasty = 100336
+
+	father = 1116
+	mother = 30854
+
+	religion = catholic
+	culture = lombard
+
+	trait = siege_leader
+	trait = skilled_tactician
+	trait = brave
+	trait = proud
+	trait = strong
+
+	martial = 8
+
+	1040.1.1 = {
+		birth = yes
+	}
+	1065.1.1 = {
+		effect = {
+			set_character_flag = special_marshal
+		}
+	}
+	1090.7.27 = {
+		death = yes
+	}
+}
+
+1129 = {
+	name = "Gaitelgrima"
+	female = yes
+	dynasty = 100336
+
+	father = 1116
+	mother = 1117
+
+	religion = catholic
+	culture = lombard
+
+	1032.1.1 = {
+		birth = yes
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+1137 = {
+	name = "Maria"
+	female = yes
+	dynasty = 100336
+
+	father = 30856
+
+	religion = catholic
+	culture = lombard
+
+	1034.1.1 = {
+		birth = yes
+	}
+	1085.1.1 = {
+		death = yes
+	}
+}
+
+30855 = {
+	name = "Gaita"
+	female = yes
+	dynasty = 100336
+
+	father = 1116
+	mother = 30854
+
+	religion = catholic
+	culture = lombard
+
+	1050.1.1 = {
+		birth = yes
+	}
+	1108.12.9 = {
+		death = yes
+	}
+}
+
+30856 = {
+	name = "Wido"
+	dynasty = 100336
+
+	father = 30857
+
+	religion = catholic
+	culture = lombard
+
+	1012.1.1 = {
+		birth = yes
+	}
+	1077.1.1 = {
+		death = yes
+	}
+}
+
+30857 = {
+	name = "Guaimar"
+	dynasty = 100336
+
+	religion = catholic
+	culture = lombard
+
+	970.1.1 = {
+		birth = yes
+	}
+	1027.2.1 = {
+		death = yes
+	}
+}
+
+30858 = {
+	name = "Landolf"
+	dynasty = 100336
+
+	father = 1116
+	mother = 30854
+
+	religion = catholic
+	culture = lombard
+
+	1036.1.1 = {
+		birth = yes
+	}
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+30859 = {
+	name = "Wido"
+	dynasty = 100336
+
+	father = 1116
+	mother = 30854
+
+	religion = catholic
+	culture = lombard
+
+	1037.1.1 = {
+		birth = yes
+	}
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+30860 = {
+	name = "Ioannes"
+	dynasty = 100336
+
+	father = 1116
+	mother = 30854
+
+	religion = catholic
+	culture = lombard
+
+	1038.1.1 = {
+		birth = yes
+	}
+	1095.1.1 = {
+		death = yes
+	}
+}
+
+30861 = {
+	name = "Guaimar"
+	dynasty = 100336
+
+	father = 1116
+	mother = 30854
+
+	religion = catholic
+	culture = lombard
+
+	1039.1.1 = {
+		birth = yes
+	}
+	1076.1.1 = {
+		death = yes
+	}
+}
+
+30863 = {
+	name = "Sichelgaita"
+	female = yes
+	dynasty = 7186
+
+	religion = catholic
+	culture = lombard
+
+	1044.1.1 = {
+		birth = yes
+	}
+	1101.9.1 = {
+		death = yes
+	}
+}
+
+163091 = {
+	name = "Guaifer"
+	dynasty = 1022178
+
+	father = 145214
+
+	religion = catholic
+	culture = lombard
+
+	830.1.1 = {
+		birth = yes
+	}
+	881.1.1 = {
+		death = yes
+	}
+}
+
+145207 = {
+	name = "Sico"
+	dynasty = 805
+
+	religion = catholic
+	culture = lombard
+
+	758.1.1 = {
+		birth = yes
+	}
+	832.9.1 = {
+		death = yes
+	}
+}
+
+145208 = {
+	name = "Sicard"
+	dynasty = 805
+
+	father = 145207
+
+	religion = catholic
+	culture = lombard
+
+	790.1.1 = {
+		birth = yes
+	}
+	839.8.1 = {
+		death = yes
+	}
+}
+
+145209 = {
+	name = "Siconolf"
+	dynasty = 805
+
+	father = 145207
+
+	religion = catholic
+	culture = lombard
+
+	792.1.1 = {
+		birth = yes
+	}
+	851.1.1 = {
+		death = yes
+	}
+}
+
+145210 = {
+	name = "Sico"
+	dynasty = 805
+
+	father = 145209
+
+	religion = catholic
+	culture = lombard
+
+	837.1.1 = {
+		birth = yes
+	}
+	855.8.1 = {
+		death = yes
+	}
+}
+
+145211 = {
+	name = "Petrus"
+	dynasty = 1022143
+
+	religion = catholic
+	culture = lombard
+
+	800.1.1 = {
+		birth = yes
+	}
+	853.12.1 = {
+		death = yes
+	}
+}
+
+145212 = {
+	name = "Ademar"
+	dynasty = 1022143
+
+	father = 145211
+
+	religion = catholic
+	culture = lombard
+
+	820.1.1 = {
+		birth = yes
+	}
+	861.8.1 = {
+		trait = blinded
+	}
+	870.1.1 = {
+		death = yes
+	}
+}
+
+145213 = {
+	name = "Daufer"
+	dynasty = 1022178
+
+	religion = catholic
+	culture = lombard
+
+	780.1.1 = {
+		birth = yes
+	}
+	840.1.1 = {
+		death = yes
+	}
+}
+
+145214 = {
+	name = "Daufer"
+	dynasty = 1022178
+
+	father = 145213
+
+	religion = catholic
+	culture = lombard
+
+	810.1.1 = {
+		birth = yes
+	}
+	860.1.1 = {
+		death = yes
+	}
+}
+
+145215 = {
+	name = "Guaimar"
+	dynasty = 1022178
+
+	father = 163091
+
+	religion = catholic
+	culture = lombard
+
+	855.1.1 = {
+		birth = yes
+	}
+	901.2.1 = {
+		death = yes
+	}
+}
+
+168424 = {
+	name = Manso
+	dynasty = 9593
+
+	father = 168420
+
+	religion = catholic
+	culture = lombard
+
+	910.1.1 = {
+		birth = yes
+	}
+	960.1.1 = {
+		death = yes
+	}
+}
+
+168425 = {
+	name = Leo
+	dynasty = 9593
+
+	father = 168424
+
+	religion = catholic
+	culture = lombard
+
+	935.1.1 = {
+		birth = yes
+	}
+	1010.1.1 = {
+		death = yes
+	}
+}
+
+168426 = {
+	name = Constantinus
+	dynasty = 9593
+
+	father = 168425
+
+	religion = catholic
+	culture = lombard
+
+	975.1.1 = {
+		birth = yes
+	}
+	1035.1.1 = {
+		death = yes
+	}
+}
+
+168427 = {
+	name = Manso
+	dynasty = 9593
+
+	father = 168425
+
+	religion = catholic
+	culture = lombard
+
+	1005.1.1 = {
+		birth = yes
+	}
+	1035.1.1 = {
+		add_spouse = 168429
+	}
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+168428 = {
+	name = Mastalo
+	dynasty = 9593
+
+	father = 168425
+
+	religion = catholic
+	culture = lombard
+
+	1010.1.1 = {
+		birth = yes
+	}
+	1077.1.1 = {
+		death = yes
+	}
+}
+
+168429 = {
+	name = Maria
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1015.1.1 = {
+		birth = yes
+	}
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+168430 = {
+	name = Leo
+	dynasty = 9593
+
+	father = 168427
+	mother = 168429
+
+	religion = catholic
+	culture = lombard
+
+	1040.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+168431 = {
+	name = Manso
+	dynasty = 9593
+
+	father = 168427
+	mother = 168429
+
+	religion = catholic
+	culture = lombard
+
+	1042.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+168432 = {
+	name = Ioannes
+	dynasty = 9593
+
+	father = 168427
+	mother = 168429
+
+	religion = catholic
+	culture = lombard
+
+	1045.1.1 = {
+		birth = yes
+	}
+	1095.1.1 = {
+		death = yes
+	}
+}
+
+168433 = {
+	name = Ursulinus
+	dynasty = 9593
+
+	father = 168431
+	trait = bastard
+
+	religion = catholic
+	culture = lombard
+
+	1060.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+168436 = {
+	name = Musco
+	dynasty = 9592
+
+	religion = catholic
+	culture = lombard
+
+	830.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+168437 = {
+	name = Sergius
+	dynasty = 9592
+
+	father = 168436
+
+	religion = catholic
+	culture = lombard
+
+	848.1.1 = {
+		birth = yes
+	}
+	910.1.1 = {
+		death = yes
+	}
+}
+
+168438 = {
+	name = Musco
+	dynasty = 9592
+
+	father = 168437
+
+	religion = catholic
+	culture = lombard
+
+	880.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+168439 = {
+	name = Sergius #Sergio II
+	dynasty = 9592
+
+	father = 168438
+
+	religion = catholic
+	culture = lombard
+
+	905.1.1 = {
+		birth = yes
+	}
+	966.12.20 = {
+		death = yes
+	}
+}
+
+168440 = {
+	name = Manso #Mansone I
+	dynasty = 9592
+
+	father = 168439
+
+	religion = catholic
+	culture = lombard
+
+	940.1.1 = {
+		birth = yes
+	}
+	1004.1.1 = {
+		death = yes
+	}
+}
+
+168441 = {
+	name = Ioannes
+	dynasty = 9592
+
+	father = 168439
+
+	religion = catholic
+	culture = lombard
+
+	945.1.1 = {
+		birth = yes
+	}
+	1007.4.27 = {
+		death = yes
+	}
+}
+
+168442 = {
+	name = Adelfer #Adelferio I
+	dynasty = 9592
+
+	father = 168439
+
+	religion = catholic
+	culture = lombard
+
+	948.1.1 = {
+		birth = yes
+	}
+	998.1.1 = {
+		death = yes
+	}
+}
+
+168443 = {
+	name = Sergius
+	dynasty = 9592
+
+	father = 168442
+
+	religion = catholic
+	culture = lombard
+
+	975.1.1 = {
+		birth = yes
+	}
+	1028.1.1 = {
+		death = yes
+	}
+}
+
+168444 = {
+	name = Maurus
+	dynasty = 9592
+
+	father = 168442
+
+	religion = catholic
+	culture = lombard
+
+	980.1.1 = {
+		birth = yes
+	}
+	1012.1.1 = {
+		death = yes
+	}
+}
+
+168445 = {
+	name = Ademar
+	dynasty = 9592
+
+	father = 168442
+
+	religion = catholic
+	culture = lombard
+
+	982.1.1 = {
+		birth = yes
+	}
+	1012.1.1 = {
+		death = yes
+	}
+}
+
+168446 = {
+	name = Leo
+	dynasty = 9592
+
+	father = 168439
+
+	religion = catholic
+	culture = lombard
+
+	950.1.1 = {
+		birth = yes
+	}
+	992.1.1 = {
+		death = yes
+	}
+}
+
+168447 = {
+	name = Purpura
+	female = yes
+	dynasty = 9592
+
+	father = 168446
+
+	religion = catholic
+	culture = lombard
+
+	975.1.1 = {
+		birth = yes
+	}
+	1037.1.1 = {
+		death = yes
+	}
+}
+
+168448 = {
+	name = Ioannes #Giovanni II
+	dynasty = 9592
+
+	father = 168440
+
+	religion = catholic
+	culture = lombard
+
+	960.1.1 = {
+		birth = yes
+	}
+	1006.6.1 = {
+		death = yes
+	}
+}
+
+168449 = {
+	name = Marinus
+	dynasty = 9592
+
+	father = 168440
+
+	religion = catholic
+	culture = lombard
+
+	965.1.1 = {
+		birth = yes
+	}
+	1011.1.1 = {
+		death = yes
+	}
+}
+
+168450 = {
+	name = Sergius
+	dynasty = 9592
+
+	father = 168440
+
+	religion = catholic
+	culture = lombard
+
+	970.1.1 = {
+		birth = yes
+	}
+	1008.11.1 = {
+		death = yes
+	}
+}
+
+168451 = {
+	name = Manso
+	dynasty = 9592
+
+	father = 168440
+
+	religion = catholic
+	culture = lombard
+
+	972.1.1 = {
+		birth = yes
+	}
+	1021.1.1 = {
+		death = yes
+	}
+}
+
+168452 = {
+	name = Landolf
+	dynasty = 9592
+
+	father = 168440
+
+	religion = catholic
+	culture = lombard
+
+	973.1.1 = {
+		birth = yes
+	}
+	1008.1.1 = {
+		death = yes
+	}
+}
+
+168453 = {
+	name = Carda
+	female = yes
+	dynasty = 9592
+
+	father = 168440
+
+	religion = catholic
+	culture = lombard
+
+	975.1.1 = {
+		birth = yes
+	}
+	1009.1.1 = {
+		death = yes
+	}
+}
+
+168454 = {
+	name = Sergius #Sergio III
+	dynasty = 9592
+
+	father = 168448
+
+	religion = catholic
+	culture = lombard
+
+	983.1.1 = {
+		birth = yes
+	}
+	1012.1.1 = {
+		add_spouse = 168496
+	}
+	1028.1.1 = {
+		death = yes
+	}
+}
+
+168455 = {
+	name = Marinus
+	dynasty = 9592
+
+	father = 168448
+
+	religion = catholic
+	culture = lombard
+
+	988.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		death = yes
+	}
+}
+
+168456 = {
+	name = Arechis
+	dynasty = 9592
+
+	father = 168448
+
+	religion = catholic
+	culture = lombard
+
+	990.1.1 = {
+		birth = yes
+	}
+	1040.1.1 = {
+		death = yes
+	}
+}
+
+168457 = {
+	name = Sergius
+	dynasty = 9592
+
+	father = 168455
+
+	religion = catholic
+	culture = lombard
+
+	1015.1.1 = {
+		birth = yes
+	}
+	1079.6.10 = {
+		death = yes
+	}
+}
+
+168458 = {
+	name = Sergius
+	dynasty = 9592
+
+	father = 168457
+
+	religion = catholic
+	culture = lombard
+
+	1035.1.1 = {
+		birth = yes
+	}
+	1079.6.10 = {
+		death = yes
+	}
+}
+
+168459 = {
+	name = Ioannes
+	dynasty = 9592
+
+	father = 168457
+
+	religion = catholic
+	culture = lombard
+
+	1037.1.1 = {
+		birth = yes
+	}
+	1079.6.10 = {
+		death = yes
+	}
+}
+
+168460 = {
+	name = Manso
+	dynasty = 9592
+
+	father = 168456
+
+	religion = catholic
+	culture = lombard
+
+	1015.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+168461 = {
+	name = Arechis
+	dynasty = 9592
+
+	father = 168460
+
+	religion = catholic
+	culture = lombard
+
+	1035.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+168462 = {
+	name = Ioannes
+	dynasty = 9592
+
+	father = 168460
+
+	religion = catholic
+	culture = lombard
+
+	1036.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+168463 = {
+	name = Aloara
+	female = yes
+	dynasty = 9592
+
+	father = 168460
+
+	religion = catholic
+	culture = lombard
+
+	1037.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+168464 = {
+	name = Stefania
+	female = yes
+	dynasty = 9592
+
+	father = 168460
+
+	religion = catholic
+	culture = lombard
+
+	1038.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+168465 = {
+	name = Regalia
+	female = yes
+	dynasty = 9592
+
+	father = 168460
+
+	religion = catholic
+	culture = lombard
+
+	1039.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+168466 = {
+	name = Ioannes #Giovanni III
+	dynasty = 9592
+
+	father = 168454
+	mother = 168496
+
+	religion = catholic
+	culture = lombard
+
+	1015.1.1 = {
+		birth = yes
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+168467 = {
+	name = Manso #Mansone III
+	dynasty = 9592
+
+	father = 168454
+	mother = 168496
+
+	religion = catholic
+	culture = lombard
+
+	1017.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		trait = blinded
+		give_nickname = nick_the_blind
+	}
+	1053.1.1 = {
+		death = yes
+	}
+}
+
+168468 = {
+	name = Rofrit
+	dynasty = 9592
+
+	father = 168454
+	mother = 168496
+
+	religion = catholic
+	culture = lombard
+
+	1019.1.1 = {
+		birth = yes
+	}
+	1058.1.1 = {
+		death = yes
+	}
+}
+
+168469 = {
+	name = Atenolf
+	dynasty = 9592
+
+	father = 168454
+	mother = 168496
+
+	religion = catholic
+	culture = lombard
+
+	1020.1.1 = {
+		birth = yes
+	}
+	1067.1.1 = {
+		death = yes
+	}
+}
+
+168470 = {
+	name = Alberic
+	dynasty = 9592
+
+	father = 168454
+	mother = 168496
+
+	religion = catholic
+	culture = lombard
+
+	1025.1.1 = {
+		birth = yes
+	}
+	1094.1.1 = {
+		death = yes
+	}
+}
+
+168471 = {
+	name = Regalia
+	female = yes
+	dynasty = 9592
+
+	father = 168454
+	mother = 168496
+
+	religion = catholic
+	culture = lombard
+
+	1016.1.1 = {
+		birth = yes
+	}
+	1076.1.1 = {
+		death = yes
+	}
+}
+
+168472 = {
+	name = Pandolf
+	dynasty = 9592
+
+	father = 168469
+
+	religion = catholic
+	culture = lombard
+
+	1040.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+168473 = {
+	name = Regalia
+	female = yes
+	dynasty = 9592
+
+	father = 168472
+
+	religion = catholic
+	culture = lombard
+
+	1060.1.1 = {
+		birth = yes
+	}
+
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+168474 = {
+	name = Guaimar #Guamario II
+	dynasty = 9592
+
+	father = 168467
+
+	religion = catholic
+	culture = lombard
+
+	1035.1.1 = {
+		birth = yes
+	}
+	1052.1.1 = {
+		death = yes
+	}
+}
+
+168475 = {
+	name = Sergius #Sergio IV
+	dynasty = 9592
+
+	father = 168466
+
+	religion = catholic
+	culture = lombard
+
+	1032.1.1 = {
+		birth = yes
+	}
+	1072.1.1 = {
+		death = yes
+	}
+}
+
+168476 = {
+	name = Ioannes #Giovanni IV
+	dynasty = 9592
+
+	father = 168475
+
+	religion = catholic
+	culture = lombard
+
+	1050.1.1 = {
+		birth = yes
+	}
+	1077.1.1 = {
+		death = yes
+	}
+}
+
+168477 = {
+	name = Ioannes
+	dynasty = 9592
+
+	father = 168436
+
+	religion = catholic
+	culture = lombard
+
+	849.1.1 = {
+		birth = yes
+	}
+	899.1.1 = {
+		death = yes
+	}
+}
+
+168478 = {
+	name = Adelfer
+	dynasty = 9592
+
+	father = 168436
+
+	religion = catholic
+	culture = lombard
+
+	850.1.1 = {
+		birth = yes
+	}
+	910.1.1 = {
+		death = yes
+	}
+}
+
+168479 = {
+	name = Maurus
+	dynasty = 9594
+
+	religion = catholic
+	culture = lombard
+
+	800.1.1 = {
+		birth = yes
+	}
+	850.1.1 = {
+		death = yes
+	}
+}
+
+168480 = {
+	name = Maurus
+	dynasty = 9594
+
+	father = 168479
+
+	religion = catholic
+	culture = lombard
+
+	820.1.1 = {
+		birth = yes
+	}
+	866.1.1 = {
+		death = yes
+	}
+}
+
+168481 = {
+	name = Stefanus
+	dynasty = 9594
+
+	father = 168480
+
+	religion = catholic
+	culture = lombard
+
+	840.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+168482 = {
+	name = Maurus
+	dynasty = 9594
+
+	father = 168481
+
+	religion = catholic
+	culture = lombard
+
+	875.1.1 = {
+		birth = yes
+	}
+	935.1.1 = {
+		death = yes
+	}
+}
+
+168483 = {
+	name = Sergius
+	dynasty = 9594
+
+	father = 168482
+
+	religion = catholic
+	culture = lombard
+
+	900.1.1 = {
+		birth = yes
+	}
+	960.1.1 = {
+		death = yes
+	}
+}
+
+168484 = {
+	name = Pandolf
+	dynasty = 9594
+
+	father = 168483
+
+	religion = catholic
+	culture = lombard
+
+	930.1.1 = {
+		birth = yes
+	}
+	990.1.1 = {
+		death = yes
+	}
+}
+
+168485 = {
+	name = Stefanus
+	dynasty = 9594
+
+	father = 168484
+
+	religion = catholic
+	culture = lombard
+
+	960.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		death = yes
+	}
+}
+
+168486 = {
+	name = Maurus
+	dynasty = 9594
+
+	father = 168485
+
+	religion = catholic
+	culture = lombard
+
+	990.1.1 = {
+		birth = yes
+	}
+	1050.1.1 = {
+		death = yes
+	}
+}
+
+168487 = {
+	name = Pandolf
+	dynasty = 9594
+
+	father = 168486
+
+	religion = catholic
+	culture = lombard
+
+	1020.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		add_spouse = 168488
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+168488 = {
+	name = Gaita
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1020.1.1 = {
+		birth = yes
+	}
+	1070.1.1 = {
+		death = yes
+	}
+}
+
+168489 = {
+	name = Landolf
+	dynasty = 9594
+
+	father = 168487
+	mother = 168488
+
+	religion = catholic
+	culture = lombard
+
+	1040.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+168490 = {
+	name = Maurus
+	dynasty = 9594
+
+	father = 168487
+	mother = 168488
+
+	religion = catholic
+	culture = lombard
+
+	1042.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+168491 = {
+	name = Pando
+	dynasty = 9594
+
+	father = 168487
+	mother = 168488
+
+	religion = catholic
+	culture = lombard
+
+	1044.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+168492 = {
+	name = Gemma
+	female = yes
+	dynasty = 9594
+
+	father = 168487
+	mother = 168488
+
+	religion = catholic
+	culture = lombard
+
+	1046.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+168493 = {
+	name = Sico
+	dynasty = 9594
+
+	father = 168479
+
+	religion = catholic
+	culture = lombard
+
+	825.1.1 = {
+		birth = yes
+	}
+	875.1.1 = {
+		death = yes
+	}
+}
+
+168494 = {
+	name = Adelfer
+	dynasty = 9594
+
+	father = 168493
+
+	religion = catholic
+	culture = lombard
+
+	847.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+168495 = {
+	name = Marada
+	female = yes
+	dynasty = 9594
+
+	father = 168493
+
+	religion = catholic
+	culture = lombard
+
+	849.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+168497 = {
+	name = Sergius
+	dynasty = 9592
+
+	father = 168470
+
+	religion = catholic
+	culture = lombard
+
+	1045.1.1 = {
+		birth = yes
+	}
+	1102.1.1 = {
+		death = yes
+	}
+}
+
+168498 = {
+	name = Maria
+	female = yes
+	dynasty = 9592
+
+	father = 168470
+
+	religion = catholic
+	culture = lombard
+
+	1046.1.1 = {
+		birth = yes
+	}
+
+	1102.1.1 = {
+		death = yes
+	}
+}
+
+73472 = {
+	name = "Ulderit"
+
+	religion = catholic
+	culture = lombard
+
+	trait = detached_priest
+
+	1010.1.1 = {
+		birth = yes
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+73474 = {
+	name = "Rofrit"
+
+	religion = catholic
+	culture = lombard
+
+	trait = detached_priest
+
+	1034.1.1 = {
+		birth = yes
+	}
+	1107.1.1 = {
+		death = yes
+	}
+}
+
+73475 = {
+	name = "Landolf"
+
+	religion = catholic
+	culture = lombard
+
+	trait = detached_priest
+
+	1066.1.1 = {
+		birth = yes
+	}
+	1119.1.1 = {
+		death = yes
+	}
+}
+
+73476 = {
+	name = "Rofrit"
+
+	religion = catholic
+	culture = lombard
+
+	trait = detached_priest
+
+	1078.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+73477 = {
+	name = "Landolf"
+
+	religion = catholic
+	culture = lombard
+
+	trait = detached_priest
+
+	1079.1.1 = {
+		birth = yes
+	}
+	1132.1.1 = {
+		death = yes
+	}
+}
+
+200298 = {
+	name = Guaimar
+	dynasty = 1022178
+
+	father = 145215
+	mother = 262155
+
+	religion = catholic
+	culture = lombard
+
+	881.1.1 = {
+		birth = yes
+	}
+	946.1.1 = {
+		death = yes
+	}
+}
+
+200299 = {
+	name = Gisulf
+	dynasty = 1022178
+
+	father = 200298
+	mother = 262440
+
+	religion = catholic
+	culture = lombard
+
+	930.1.1 = {
+		birth = yes
+	}
+	977.11.1 = {
+		death = yes
+	}
+}
+
+200300 = {
+	name = Daufer
+	dynasty = 1022178
+
+	father = 163091
+
+	religion = catholic
+	culture = lombard
+
+	860.1.1 = {
+		birth = yes
+	}
+	928.1.1 = {
+		death = yes
+	}
+}
+
+200301 = {
+	name = Maio
+	dynasty = 1022178
+
+	father = 200300
+
+	religion = catholic
+	culture = lombard
+
+	885.1.1 = {
+		birth = yes
+	}
+	963.3.1 = {
+		death = yes
+	}
+}
+
+200302 = {
+	name = Truppoald
+	dynasty = 1022178
+
+	father = 200301
+
+	religion = catholic
+	culture = lombard
+
+	916.1.1 = {
+		birth = yes
+	}
+	980.3.1 = {
+		death = yes
+	}
+}
+
+200303 = {
+	name = Alfan
+	dynasty = 1022178
+
+	father = 200302
+
+	religion = catholic
+	culture = lombard
+
+	951.1.1 = {
+		birth = yes
+	}
+	1019.6.1 = {
+		death = yes
+	}
+}
+
+200304 = {
+	name = Petrus
+	dynasty = 1022178
+
+	father = 200303
+
+	religion = catholic
+	culture = lombard
+
+	990.1.1 = {
+		birth = yes
+	}
+	1072.5.1 = {
+		death = yes
+	}
+}
+
+200305 = {
+	name = Alfan
+	dynasty = 1022178
+
+	father = 200304
+
+	religion = catholic
+	culture = lombard
+
+	1006.1.1 = {
+		birth = yes
+	}
+	1079.8.1 = {
+		death = yes
+	}
+}
+
+200306 = {
+	name = Petrus
+	dynasty = 1022178
+
+	father = 200305
+
+	religion = catholic
+	culture = lombard
+
+	1032.1.1 = {
+		birth = yes
+	}
+	1084.1.1 = {
+		death = yes
+	}
+}
+
+200307 = {
+	name = Wido
+	dynasty = 1022178
+
+	father = 145215
+
+	religion = catholic
+	culture = lombard
+
+	884.1.1 = {
+		birth = yes
+	}
+	940.4.1 = {
+		death = yes
+	}
+}
+
+200308 = {
+	name = Guaimar
+	dynasty = 1022178
+
+	father = 200307
+
+	religion = catholic
+	culture = lombard
+
+	910.1.1 = {
+		birth = yes
+	}
+	974.12.1 = {
+		death = yes
+	}
+}
+
+200309 = {
+	name = Wido
+	dynasty = 1022178
+
+	father = 200308
+
+	religion = catholic
+	culture = lombard
+
+	937.1.1 = {
+		birth = yes
+	}
+	991.5.1 = {
+		death = yes
+	}
+}
+
+200310 = {
+	name = Gisulf
+	dynasty = 1022178
+
+	father = 200309
+
+	religion = catholic
+	culture = lombard
+
+	966.1.1 = {
+		birth = yes
+	}
+	1027.1.1 = {
+		death = yes
+	}
+}
+
+200311 = {
+	name = Astolf
+	dynasty = 1022178
+
+	father = 200310
+
+	religion = catholic
+	culture = lombard
+
+	1000.1.1 = {
+		birth = yes
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+200312 = {
+	name = Lando
+	dynasty = 1022178
+
+	father = 200310
+
+	religion = catholic
+	culture = lombard
+
+	1002.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+200313 = {
+	name = Wido
+	dynasty = 1022178
+
+	father = 200312
+
+	religion = catholic
+	culture = lombard
+
+	1030.1.1 = {
+		birth = yes
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+200314 = {
+	name = Guaifer
+	dynasty = 1022178
+
+	father = 200310
+
+	religion = catholic
+	culture = lombard
+
+	1004.1.1 = {
+		birth = yes
+	}
+	1078.2.1 = {
+		death = yes
+	}
+}
+
+200315 = {
+	name = Wido
+	dynasty = 1022178
+
+	father = 200314
+
+	religion = catholic
+	culture = lombard
+
+	1030.1.1 = {
+		birth = yes
+	}
+	1078.2.1 = {
+		death = yes
+	}
+}
+
+200316 = {
+	name = Iaquintus
+	dynasty = 1022178
+
+	father = 200315
+
+	religion = catholic
+	culture = lombard
+
+	1058.1.1 = {
+		birth = yes
+	}
+	1097.8.1 = {
+		death = yes
+	}
+}
+
+200317 = {
+	name = Guaifer
+	dynasty = 1022178
+
+	father = 200307
+
+	religion = catholic
+	culture = lombard
+
+	914.1.1 = {
+		birth = yes
+	}
+	981.5.1 = {
+		death = yes
+	}
+}
+
+200318 = {
+	name = Guaimar
+	dynasty = 1022178
+
+	father = 200317
+
+	religion = catholic
+	culture = lombard
+
+	931.1.1 = {
+		birth = yes
+	}
+	991.10.1 = {
+		death = yes
+	}
+}
+
+200319 = {
+	name = Guaimar
+	dynasty = 1022178
+
+	father = 200318
+
+	religion = catholic
+	culture = lombard
+
+	961.1.1 = {
+		birth = yes
+	}
+	1037.8.1 = {
+		death = yes
+	}
+}
+
+200320 = {
+	name = Guaimar
+	dynasty = 1022178
+
+	father = 200319
+
+	religion = catholic
+	culture = lombard
+
+	987.1.1 = {
+		birth = yes
+	}
+	1044.5.1 = {
+		death = yes
+	}
+}
+
+200321 = {
+	name = Guaimar
+	dynasty = 1022178
+
+	father = 200320
+
+	religion = catholic
+	culture = lombard
+
+	1010.1.1 = {
+		birth = yes
+	}
+	1068.4.1 = {
+		death = yes
+	}
+}
+
+200322 = {
+	name = Petrus
+	dynasty = 1022178
+
+	father = 200321
+
+	religion = catholic
+	culture = lombard
+
+	1033.1.1 = {
+		birth = yes
+	}
+	1088.1.1 = {
+		death = yes
+	}
+}
+
+200323 = {
+	name = Guaifer
+	dynasty = 1022178
+
+	father = 200322
+
+	religion = catholic
+	culture = lombard
+
+	1050.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+200324 = {
+	name = Wida
+	female = yes
+	dynasty = 100336
+
+	father = 30856
+
+	religion = catholic
+	culture = lombard
+
+	1031.1.1 = {
+		birth = yes
+	}
+	1094.1.1 = {
+		death = yes
+	}
+}
+
+200325 = {
+	name = Guaimar
+	dynasty = 100336
+
+	father = 30856
+
+	religion = catholic
+	culture = lombard
+
+	1032.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		add_spouse = 200326
+	}
+	1091.10.1 = {
+		death = yes
+	}
+}
+
+200326 = {
+	name = Sichelgarda
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1060.1.1 = {
+		birth = yes
+	}
+	1118.1.1 = {
+		death = yes
+	}
+}
+
+200327 = {
+	name = Ioannes
+	dynasty = 100336
+
+	father = 200325
+
+	religion = catholic
+	culture = lombard
+
+	1057.1.1 = {
+		birth = yes
+	}
+	1091.10.1 = {
+		death = yes
+	}
+}
+
+200328 = {
+	name = Guaimar
+	dynasty = 100336
+
+	father = 200325
+
+	religion = catholic
+	culture = lombard
+
+	1059.1.1 = {
+		birth = yes
+	}
+	1114.3.1 = {
+		death = yes
+	}
+}
+
+200329 = {
+	name = Mabilia
+	female = yes
+	dynasty = 100336
+
+	father = 200325
+	mother = 200326
+
+	religion = catholic
+	culture = lombard
+
+	1081.1.1 = {
+		birth = yes
+	}
+	1143.2.1 = {
+		death = yes
+	}
+}
+
+200331 = {
+	name = Pandolf
+	dynasty = 100336
+
+	father = 30856
+
+	religion = catholic
+	culture = lombard
+
+	1033.1.1 = {
+		birth = yes
+	}
+	1091.1.1 = {
+		death = yes
+	}
+}
+
+200332 = {
+	name = Landolf
+	dynasty = 100336
+
+	father = 200331
+
+	religion = catholic
+	culture = lombard
+
+	1058.1.1 = {
+		birth = yes
+	}
+	1124.1.1 = {
+		death = yes
+	}
+}
+
+200333 = {
+	name = Paldolf
+	dynasty = 100336
+
+	father = 30857
+
+	religion = catholic
+	culture = lombard
+
+	1014.1.1 = {
+		birth = yes
+	}
+	1040.1.1 = {
+		add_spouse = 200334
+	}
+	1052.6.3 = {
+		death = yes
+	}
+}
+
+200335 = {
+	name = Guaimar
+	dynasty = 100336
+
+	father = 200333
+	mother = 200334
+
+	religion = catholic
+	culture = lombard
+
+	1041.1.1 = {
+		birth = yes
+	}
+	1059.1.1 = {
+		add_spouse = 73344
+	}
+	1100.8.1 = {
+		death = yes
+	}
+}
+
+200336 = {
+	name = Pandolf
+	dynasty = 100336
+
+	father = 200335
+	mother = 73344
+
+	religion = catholic
+	culture = lombard
+
+	1060.1.1 = {
+		birth = yes
+	}
+	1104.1.1 = {
+		death = yes
+	}
+}
+
+200337 = {
+	name = William
+	dynasty = 100336
+
+	father = 200336
+
+	religion = catholic
+	culture = lombard
+
+	1084.1.1 = {
+		birth = yes
+	}
+	1134.5.1 = {
+		death = yes
+	}
+}
+
+200338 = {
+	name = Gisulf
+	dynasty = 100336
+
+	father = 200337
+
+	religion = catholic
+	culture = lombard
+
+	1110.1.1 = {
+		birth = yes
+	}
+	1167.1.1 = {
+		death = yes
+	}
+}
+
+200339 = {
+	name = William
+	dynasty = 100336
+
+	father = 200338
+
+	religion = catholic
+	culture = lombard
+
+	1133.1.1 = {
+		birth = yes
+	}
+	1187.1.1 = {
+		death = yes
+	}
+}
+
+200340 = {
+	name = Gisulf
+	dynasty = 100336
+
+	father = 200336
+
+	religion = catholic
+	culture = lombard
+
+	1086.1.1 = {
+		birth = yes
+	}
+	1134.5.1 = {
+		death = yes
+	}
+}
+
+200341 = {
+	name = Emma
+	female = yes
+	dynasty = 100336
+
+	father = 200336
+
+	religion = catholic
+	culture = lombard
+
+	1088.1.1 = {
+		birth = yes
+	}
+	1167.1.1 = {
+		death = yes
+	}
+}
+
+200342 = {
+	name = Gregorius
+	dynasty = 100336
+
+	father = 200335
+	mother = 73344
+
+	religion = catholic
+	culture = lombard
+
+	1062.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+200343 = {
+	name = Hermann
+	dynasty = 100336
+
+	father = 200342
+
+	religion = catholic
+	culture = lombard
+
+	1084.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+200344 = {
+	name = Pandolf
+	dynasty = 100336
+
+	father = 200342
+
+	religion = catholic
+	culture = lombard
+
+	1086.1.1 = {
+		birth = yes
+	}
+	1154.10.1 = {
+		death = yes
+	}
+}
+
+200345 = {
+	name = Abelard
+	dynasty = 100336
+
+	father = 200342
+
+	religion = catholic
+	culture = lombard
+
+	1088.1.1 = {
+		birth = yes
+	}
+	1154.10.1 = {
+		death = yes
+	}
+}
+
+200346 = {
+	name = Gemma
+	female = yes
+	dynasty = 100336
+
+	father = 200342
+
+	religion = catholic
+	culture = lombard
+
+	1090.1.1 = {
+		birth = yes
+	}
+	1138.1.1 = {
+		death = yes
+	}
+}
+
+200347 = {
+	name = Guaimar
+	dynasty = 100336
+
+	father = 200335
+#	mother = 7344
+
+	religion = catholic
+	culture = lombard
+
+	1064.1.1 = {
+		birth = yes
+	}
+	1137.12.5 = {
+		death = yes
+	}
+}
+
+200348 = {
+	name = Guaimar
+	dynasty = 100336
+
+	father = 200347
+
+	religion = catholic
+	culture = lombard
+
+	1090.1.1 = {
+		birth = yes
+	}
+	1137.12.1 = {
+		death = yes
+	}
+}
+
+200349 = {
+	name = Gisulf
+	dynasty = 100336
+
+	father = 200335
+	mother = 73344
+
+	religion = catholic
+	culture = lombard
+
+	1066.1.1 = {
+		birth = yes
+	}
+	1119.1.1 = {
+		death = yes
+	}
+}
+
+200351 = {
+	name = Tudinus
+	dynasty = 100336
+
+	father = 200335
+	mother = 73344
+
+	religion = catholic
+	culture = lombard
+
+	1068.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+200352 = {
+	name = Gregorius
+	dynasty = 100336
+
+	father = 200333
+	mother = 200334
+
+	religion = catholic
+	culture = lombard
+
+	1043.1.1 = {
+		birth = yes
+	}
+#	1075.1.1 = {
+#		add_spouse = 200732	# doesn't exist
+#	}
+	1119.1.1 = {
+		death = yes
+	}
+}
+
+200353 = {
+	name = Herbert
+	dynasty = 100336
+
+	father = 200352
+
+	religion = catholic
+	culture = lombard
+
+	1066.1.1 = {
+		birth = yes
+	}
+	1096.1.1 = {
+		death = yes
+	}
+}
+
+200354 = {
+	name = Ioannes
+	dynasty = 100336
+
+	father = 200352
+
+	religion = catholic
+	culture = lombard
+
+	1068.1.1 = {
+		birth = yes
+	}
+	1132.1.1 = {
+		death = yes
+	}
+}
+
+200355 = {
+	name = William
+	dynasty = 100336
+
+	father = 200352
+	mother = 200372
+
+	religion = catholic
+	culture = lombard
+
+	1076.1.1 = {
+		birth = yes
+	}
+	1134.1.1 = {
+		death = yes
+	}
+}
+
+200356 = {
+	name = Robert
+	dynasty = 100336
+
+	father = 200355
+
+	religion = catholic
+	culture = lombard
+
+	1097.1.1 = {
+		birth = yes
+	}
+	1119.1.1 = {
+		add_spouse = 200357
+	}
+	1156.10.3 = {
+		death = yes
+	}
+}
+
+200357 = {
+	name = Lolegrima
+	female = yes
+
+	religion = catholic
+	culture = lombard
+
+	1100.1.1 = {
+		birth = yes
+	}
+	1156.10.3 = {
+		death = yes
+	}
+}
+
+200358 = {
+	name = Wido
+	dynasty = 100336
+
+	father = 200356
+	mother = 200357
+
+	religion = catholic
+	culture = lombard
+
+	1120.1.1 = {
+		birth = yes
+	}
+	1170.1.1 = {
+		death = yes
+	}
+}
+
+200359 = {
+	name = Sophia
+	female = yes
+	dynasty = 100336
+
+	father = 200352
+	mother = 200372
+
+	religion = catholic
+	culture = lombard
+
+	1078.1.1 = {
+		birth = yes
+	}
+	1120.1.1 = {
+		death = yes
+	}
+}
+
+200360 = {
+	name = Ioannes
+	dynasty = 100336
+
+	father = 200333
+	mother = 200334
+
+	religion = catholic
+	culture = lombard
+
+	1045.1.1 = {
+		birth = yes
+	}
+	1070.1.1 = {
+		add_spouse = 200392
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+200361 = {
+	name = Jordan
+	dynasty = 100336
+
+	father = 200360
+	mother = 200392
+
+	religion = catholic
+	culture = lombard
+
+	1071.1.1 = {
+		birth = yes
+	}
+	1137.1.1 = {
+		death = yes
+	}
+}
+
+200362 = {
+	name = Emma
+	female = yes
+	dynasty = 100336
+
+	father = 200360
+	mother = 200392
+
+	religion = catholic
+	culture = lombard
+
+	1073.1.1 = {
+		birth = yes
+	}
+	1134.10.1 = {
+		death = yes
+	}
+}
+
+200363 = {
+	name = Wido
+	dynasty = 100336
+
+	father = 200333
+	mother = 200334
+
+	religion = catholic
+	culture = lombard
+
+	1047.1.1 = {
+		birth = yes
+	}
+	1068.7.1 = {
+		death = yes
+	}
+}
+
+200364 = {
+	name = Sichelgaita
+	female = yes
+	dynasty = 100336
+
+	father = 200333
+	mother = 200334
+
+	religion = catholic
+	culture = lombard
+
+	1049.1.1 = {
+		birth = yes
+	}
+	1086.5.1 = {
+		death = yes
+	}
+}
+
+200365 = {
+	name = Theodora
+	female = yes
+	dynasty = 100336
+
+	father = 200333
+	mother = 200334
+
+	religion = catholic
+	culture = lombard
+
+	1051.1.1 = {
+		birth = yes
+	}
+	1101.1.1 = {
+		death = yes
+	}
+}
+
+200367 = {
+	name = Landolf
+	dynasty = 7184
+
+	father = 73340
+
+	religion = catholic
+	culture = lombard
+
+	1007.1.1 = {
+		birth = yes
+	}
+	1065.1.19 = {
+		death = yes
+	}
+}
+
+200368 = {
+	name = Ioannes
+	dynasty = 7184
+
+	father = 200367
+
+	religion = catholic
+	culture = lombard
+
+	1031.1.1 = {
+		birth = yes
+	}
+	1086.7.1 = {
+		death = yes
+	}
+}
+
+200369 = {
+	name = Paldo
+	dynasty = 7184
+
+	father = 200368
+
+	religion = catholic
+	culture = lombard
+
+	1055.1.1 = {
+		birth = yes
+	}
+	1123.6.1 = {
+		death = yes
+	}
+}
+
+200370 = {
+	name = Atenolf
+	dynasty = 7184
+
+	father = 200369
+
+	religion = catholic
+	culture = lombard
+
+	1090.1.1 = {
+		birth = yes
+	}
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+200371 = {
+	name = Altruda
+	female = yes
+	dynasty = 7184
+
+	father = 200368
+
+	religion = catholic
+	culture = lombard
+
+	1057.1.1 = {
+		birth = yes
+	}
+	1104.11.1 = {
+		death = yes
+	}
+}
+
+200372 = {
+	name = Sichelgaita
+	female = yes
+	dynasty = 7184
+
+	father = 200368
+
+	religion = catholic
+	culture = lombard
+
+	1059.1.1 = {
+		birth = yes
+	}
+	1119.1.1 = {
+		death = yes
+	}
+}
+
+200373 = {
+	name = Landolf
+	dynasty = 7184
+
+	father = 200367
+
+	religion = catholic
+	culture = lombard
+
+	1050.1.1 = {
+		birth = yes
+	}
+	1070.9.1 = {
+		death = yes
+	}
+}
+
+200374 = {
+	name = Gisulf
+	dynasty = 7184
+
+	father = 73339
+
+	religion = catholic
+	culture = lombard
+
+	984.1.1 = {
+		birth = yes
+	}
+	1011.1.1 = {
+		death = yes
+	}
+}
+
+200375 = {
+	name = Ioannes
+	dynasty = 7184
+
+	father = 200374
+
+	religion = catholic
+	culture = lombard
+
+	1006.1.1 = {
+		birth = yes
+	}
+	1065.1.19 = {
+		death = yes
+	}
+}
+
+200376 = {
+	name = Petrus
+	dynasty = 7184
+
+	father = 200375
+
+	religion = catholic
+	culture = lombard
+
+	1031.1.1 = {
+		birth = yes
+	}
+	1116.10.1 = {
+		death = yes
+	}
+}
+
+200377 = {
+	name = Ioannes
+	dynasty = 7184
+
+	father = 200376
+
+	religion = catholic
+	culture = lombard
+
+	1055.1.1 = {
+		birth = yes
+	}
+	1116.10.1 = {
+		death = yes
+	}
+}
+
+200378 = {
+	name = Laidolf
+	dynasty = 7184
+
+	father = 200374
+
+	religion = catholic
+	culture = lombard
+
+	1007.1.1 = {
+		birth = yes
+	}
+	1065.1.19 = {
+		death = yes
+	}
+}
+
+200379 = {
+	name = Pandolf
+	dynasty = 7184
+
+	father = 200378
+
+	religion = catholic
+	culture = lombard
+
+	1030.1.1 = {
+		birth = yes
+	}
+	1089.12.7 = {
+		death = yes
+	}
+}
+
+200380 = {
+	name = Pandolf
+	dynasty = 7184
+
+	father = 200379
+
+	religion = catholic
+	culture = lombard
+
+	1054.1.1 = {
+		birth = yes
+	}
+	1091.9.1 = {
+		death = yes
+	}
+}
+
+200381 = {
+	name = Hector
+	dynasty = 7184
+
+	father = 200380
+
+	religion = catholic
+	culture = lombard
+
+	1077.1.1 = {
+		birth = yes
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+200382 = {
+	name = Laidolf
+	dynasty = 7184
+
+	father = 200380
+
+	religion = catholic
+	culture = lombard
+
+	1079.1.1 = {
+		birth = yes
+	}
+	1108.9.1 = {
+		death = yes
+	}
+}
+
+200383 = {
+	name = Pandolf
+	dynasty = 7184
+
+	father = 200380
+
+	religion = catholic
+	culture = lombard
+
+	1081.1.1 = {
+		birth = yes
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+200384 = {
+	name = Gisulf
+	dynasty = 7184
+
+	father = 200380
+
+	religion = catholic
+	culture = lombard
+
+	1083.1.1 = {
+		birth = yes
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+200385 = {
+	name = Landenolf
+	dynasty = 7184
+
+	father = 200379
+
+	religion = catholic
+	culture = lombard
+
+	1056.1.1 = {
+		birth = yes
+	}
+	1101.8.1 = {
+		death = yes
+	}
+}
+
+200386 = {
+	name = Landolf
+	dynasty = 7184
+
+	father = 200385
+
+	religion = catholic
+	culture = lombard
+
+	1079.1.1 = {
+		birth = yes
+	}
+	1097.9.1 = {
+		death = yes
+	}
+}
+
+200387 = {
+	name = Laidolf
+	dynasty = 7184
+
+	father = 200385
+
+	religion = catholic
+	culture = lombard
+
+	1081.1.1 = {
+		birth = yes
+	}
+	1097.1.1 = {
+		death = yes
+	}
+}
+
+200388 = {
+	name = Landolf
+	dynasty = 7184
+
+	father = 73332
+
+	religion = catholic
+	culture = lombard
+
+	935.1.1 = {
+		birth = yes
+	}
+	1002.1.1 = {
+		death = yes
+	}
+}
+
+200389 = {
+	name = Landolf
+	dynasty = 7184
+
+	father = 200388
+
+	religion = catholic
+	culture = lombard
+
+	963.1.1 = {
+		birth = yes
+	}
+	1003.3.1 = {
+		death = yes
+	}
+}
+
+200390 = {
+	name = Landolf
+	dynasty = 7184
+
+	father = 200389
+
+	religion = catholic
+	culture = lombard
+
+	987.1.1 = {
+		birth = yes
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+200391 = {
+	name = Landolf
+	dynasty = 7184
+
+	father = 200390
+
+	religion = catholic
+	culture = lombard
+
+	1018.1.1 = {
+		birth = yes
+	}
+	1083.1.1 = {
+		death = yes
+	}
+}
+
+200392 = {
+	name = Ageltruda
+	female = yes
+	dynasty = 7184
+
+	father = 200391
+
+	religion = catholic
+	culture = lombard
+
+	1045.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+200393 = {
+	name = Lando
+	dynasty = 7184
+
+	father = 200390
+
+	religion = catholic
+	culture = lombard
+
+	1020.1.1 = {
+		birth = yes
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+200394 = {
+	name = Offa
+	female = yes
+	dynasty = 7184
+
+	father = 200393
+
+	religion = catholic
+	culture = lombard
+
+	1050.1.1 = {
+		birth = yes
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+218000 = {
+	name = Leopold
+	female = no
+
+	religion = catholic
+	culture = lombard
+	740.1.1 = {
+		birth = yes
+	}
+	793.1.1 = {
+		death = yes
+	}
+}
+
+221100 = {
+	name = Adaloald
+	dynasty = 1062609
+	female = no
+	religion = catholic
+	culture = lombard
+	745.1.1 = {
+		birth = yes
+	}
+	804.1.1 = {
+		death = yes
+	}
+}
+
+221101 = {
+	name = Faroald
+	dynasty = 1044083
+	female = no
+	religion = catholic
+	culture = lombard
+	834.1.1 = {
+		birth = yes
+	}
+	901.1.1 = {
+		death = yes
+	}
+}
+
+262440 = {
+	name = Gaitelgrima
+	dynasty = 7184
+	female = yes
+	religion = catholic
+	culture = lombard
+	father = 73331
+	trait = charismatic_negotiator
+	890.1.1 = {
+		birth = yes
+	}
+	926.1.1 = {
+		add_spouse = 200298
+	}
+	950.1.1 = {
+		death = yes
+	}
+}
+
+262441 = {
+	name = Rotilda
+	dynasty = 1022178
+	female = yes
+	religion = catholic
+	culture = lombard
+	father = 200298
+	910.1.1 = {
+		birth = yes
+	}
+	926.1.1 = {
+		add_spouse = 73329
+	}
+	950.1.1 = {
+		death = yes
+	}
+}

--- a/CK2Plus_expanded/history/characters/maghreb_arabic.txt
+++ b/CK2Plus_expanded/history/characters/maghreb_arabic.txt
@@ -1,0 +1,10752 @@
+# Called "Berber" in-game
+
+6882 = {
+	name = Berkan # Fantasy
+	dynasty = 841
+	religion = sunni
+	culture = maghreb_arabic
+	825.1.1 = {
+		birth = yes
+	}
+	880.1.1 = {
+		death = yes
+	}
+}
+
+6883 = {
+	name = Mezwar # Fantasy
+	dynasty = 842
+	religion = sunni
+	culture = maghreb_arabic
+	829.1.1 = {
+		birth = yes
+	}
+	885.1.1 = {
+		death = yes
+	}
+}
+
+6884 = {
+	name = Firhun # Fantasy
+	dynasty = 843
+	religion = sunni
+	culture = maghreb_arabic
+	830.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+6885 = {
+	name = Agdun # Fantasy
+	dynasty = 844
+	religion = sunni
+	culture = maghreb_arabic
+	830.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+6886 = {
+	name = Tegama # Fantasy
+	dynasty = 845
+	religion = sunni
+	culture = maghreb_arabic
+	831.1.1 = {
+		birth = yes
+	}
+	891.1.1 = {
+		death = yes
+	}
+}
+
+6887 = {
+	name = Isli # Fantasy
+	dynasty = 846
+	religion = sunni
+	culture = maghreb_arabic
+	832.1.1 = {
+		birth = yes
+	}
+	896.1.1 = {
+		death = yes
+	}
+}
+
+6888 = {
+	name = Yabdas # Fantasy
+	dynasty = 847
+	religion = sunni
+	culture = maghreb_arabic
+	830.1.1 = {
+		birth = yes
+	}
+	894.1.1 = {
+		death = yes
+	}
+}
+
+144232 = {
+	name = "Amin"
+	dynasty = 793
+	religion = shiite
+	culture = maghreb_arabic
+	1030.1.1 = {
+		birth = yes
+	}
+	1072.1.1 = {
+		death = yes
+	}
+}
+
+144233 = {
+	name = "Jala"
+	dynasty = 793
+	religion = shiite
+	culture = maghreb_arabic
+	father = 144232
+	1050.1.1 = {
+		birth = yes
+	}
+	1099.1.1 = {
+		death = yes
+	}
+}
+
+144234 = {
+	name = "Fakhr"
+	dynasty = 793
+	religion = shiite
+	culture = maghreb_arabic
+	father = 144232
+	1052.1.1 = {
+		birth = yes
+	}
+	1109.7.12 = {
+		death = yes
+	}
+}
+
+20769 = {
+	name = "Mes'ud"
+	#placeholder
+	dynasty = 577
+	martial = 7
+	diplomacy = 6
+	intrigue = 7
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = cynical
+	trait = martial_cleric
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+#20798 = {
+#	name = "Ishaq"
+#	dynasty = 101671
+#	martial = 6
+#	diplomacy = 5
+#	intrigue = 5
+#	stewardship = 7
+#	religion = sunni
+#	culture = maghreb_arabic
+#	trait = slothful
+#	trait = tough_soldier
+#	1039.1.1 = {
+#		birth = yes
+#	}
+#	1089.1.1 = {
+#		death = yes
+#	}
+#}
+
+20801 = {
+	name = "Sha'ban"
+	#placeholder
+	martial = 8
+	diplomacy = 4
+	intrigue = 8
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = patient
+	trait = cynical
+	trait = hunchback
+	trait = martial_cleric
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+#20803 = {
+#	name = "Abdul-Wahab"
+#	# AKA: Abdul
+#	dynasty = 101056
+#	martial = 4
+#	diplomacy = 8
+#	intrigue = 7
+#	stewardship = 8
+#	religion = sunni
+#	culture = maghreb_arabic
+#	trait = deceitful
+#	trait = skilled_tactician
+#	1039.1.1 = {
+#		birth = yes
+#	}
+#	1089.1.1 = {
+#		death = yes
+#	}
+#}
+
+20804 = {
+	name = "Tariq"
+	dynasty = 101055
+	martial = 8
+	diplomacy = 6
+	intrigue = 8
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = humble
+	trait = gluttonous
+	trait = underhanded_rogue
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+#20806 = {
+#	name = "Isa"
+#	dynasty = 101053
+#	martial = 6
+#	diplomacy = 8
+#	intrigue = 5
+#	stewardship = 5
+#	religion = sunni
+#	culture = maghreb_arabic
+#	trait = patient
+#	trait = cynical
+#	trait = hunchback
+#	trait = amateurish_plotter
+#	1039.1.1 = {
+#		birth = yes
+#	}
+#	1089.1.1 = {
+#		death = yes
+#	}
+#}
+
+20807 = {
+	name = "Abbas"
+	dynasty = 101052
+	martial = 4
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20808 = {
+	name = "Shamsaddin"
+	#placeholder
+	martial = 8
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20809 = {
+	name = "Abdul-Haleem"
+	# AKA: Abdul
+	dynasty = 101731
+	martial = 4
+	diplomacy = 8
+	intrigue = 8
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = scholarly_theologian
+	father = 155137
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20811 = {
+	name = "Sa'daddin"
+	dynasty = 101049
+	martial = 8
+	diplomacy = 7
+	intrigue = 7
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20820 = {
+	name = "Amr"
+	dynasty = 101168
+	martial = 5
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = honest
+	trait = arbitrary
+	trait = tough_soldier
+	trait = cynical
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20823 = {
+	name = "Isa"
+	dynasty = 101041
+	martial = 6
+	diplomacy = 6
+	intrigue = 7
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = scholarly_theologian
+	trait = cynical
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20825 = {
+	name = "Tamim" #Tunis 1062 - 1108
+	dynasty = 595
+	martial = 7
+	diplomacy = 5
+	intrigue = 8
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = envious
+	trait = skilled_tactician
+	father = 20935
+	1040.1.1 = {
+		birth = yes
+	}
+	1108.1.1 = {
+		death = yes
+	}
+}
+
+20832 = {
+	name = "Ayyub"
+	dynasty = 595
+	martial = 6
+	diplomacy = 7
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = diligent
+	trait = deceitful
+	trait = scholarly_theologian
+	father = 85007
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20834 = {
+	name = "an-Nasir" #Alger 1062-1088
+	# AKA: al
+	dynasty = 575
+	martial = 5
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = diligent
+	trait = wroth
+	trait = scholarly_theologian
+	father = 20937
+	1042.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		add_spouse = 155090
+	}
+	1088.1.1 = {
+		death = yes
+	}
+}
+
+20842 = {
+	name = "Guanarigato"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166432
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20850 = {
+	name = "Jawdat"
+	dynasty = 101733
+	martial = 6
+	diplomacy = 8
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = fortune_builder
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20930 = {
+	name = "Manad"
+	dynasty = 595
+	martial = 4
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 6
+	religion = shiite
+	culture = maghreb_arabic
+	870.1.1 = {
+		birth = yes
+	}
+	920.1.1 = {
+		death = yes
+	}
+}
+
+20931 = {
+	name = "Ziri" #Tunis 920 - 973
+	dynasty = 595 #banu Ziri
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = shiite
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	father = 20930
+	910.1.1 = {
+		birth = yes
+	}
+	973.1.1 = {
+		death = yes
+	}
+}
+
+20932 = {
+	name = "Buluggin" #Tunis 973-984
+	dynasty = 595
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = shiite
+	culture = maghreb_arabic
+	trait = fortune_builder
+	father = 20931
+	931.1.1 = {
+		birth = yes
+	}
+	984.1.1 = {
+		death = yes
+	}
+}
+
+20933 = {
+	name = "al-Mansur" #Tunis 984 - 995
+	# AKA: Abu
+	dynasty = 595
+	martial = 5
+	diplomacy = 5
+	intrigue = 4
+	stewardship = 6
+	religion = shiite
+	culture = maghreb_arabic
+	trait = tough_soldier
+	father = 20932
+	948.1.1 = {
+		birth = yes
+	}
+	995.1.1 = {
+		death = yes
+	}
+}
+
+20934 = {
+	name = "Badis" #Tunis 995 - 1015
+	dynasty = 595
+	martial = 4
+	diplomacy = 5
+	intrigue = 9
+	stewardship = 6
+	religion = shiite
+	culture = maghreb_arabic
+	father = 20933
+	965.1.1 = {
+		birth = yes
+	}
+	1015.1.1 = {
+		death = yes
+	}
+}
+
+20935 = {
+	name = "al-Muizz" #Tunis 1015 - 1062
+	# AKA: al
+	dynasty = 595
+	martial = 4
+	diplomacy = 5
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	father = 20934
+	1000.1.1 = {
+		birth = yes
+	}
+	1062.1.1 = {
+		death = yes
+	}
+}
+
+20936 = {
+	name = "Hammad" #Alger 1014-1028
+	dynasty = 575
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	trait = ambitious
+	father = 20932
+	965.1.1 = {
+		birth = yes
+	}
+	1028.1.1 = {
+		death = yes
+	}
+}
+
+20937 = {
+	name = "'Alennas"
+	# AKA: Alennas
+	dynasty = 575 #nam Hammad
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	father = 20936
+	1000.1.1 = {
+		birth = yes
+	}
+	1062.1.1 = {
+		death = yes
+	}
+}
+
+220842 = {
+	name = "Hussamaddin"
+	dynasty = 100848
+	martial = 5
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224018 = {
+	name = "Abdul-Aziz"
+	# AKA: Abdul
+	dynasty = 100839
+	martial = 4
+	diplomacy = 4
+	intrigue = 8
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = deceitful
+	trait = just
+	trait = envious
+	trait = amateurish_plotter
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224019 = {
+	name = "Ibrahim"
+	dynasty = 100841
+	martial = 6
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = just
+	trait = patient
+	trait = charismatic_negotiator
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224026 = {
+	name = "Abdul-Rahman"
+	# AKA: Abdul
+	dynasty = 100817
+	martial = 4
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = wroth
+	trait = cynical
+	trait = stutter
+	trait = skilled_tactician
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224027 = {
+	name = "Abdul-Haleem"
+	# AKA: Abdul
+	dynasty = 100815
+	martial = 4
+	diplomacy = 8
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = flamboyant_schemer
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224028 = {
+	name = "Muslihiddin"
+	dynasty = 100816
+	martial = 7
+	diplomacy = 5
+	intrigue = 6
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = lustful
+	trait = tough_soldier
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224029 = {
+	name = "Da'ud"
+	dynasty = 100819
+	martial = 5
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = arbitrary
+	trait = skilled_tactician
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224030 = {
+	name = "Husseyn"
+	dynasty = 100820
+	martial = 6
+	diplomacy = 6
+	intrigue = 8
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = amateurish_plotter
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224031 = {
+	name = "Da'ud"
+	dynasty = 100818
+	martial = 5
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = patient
+	trait = fortune_builder
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224032 = {
+	name = "Muhammad"
+	dynasty = 100821
+	martial = 7
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = slothful
+	trait = scholarly_theologian
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224033 = {
+	name = "Salim"
+	dynasty = 100822
+	martial = 8
+	diplomacy = 8
+	intrigue = 4
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224034 = {
+	name = "Zakariah"
+	dynasty = 100823
+	martial = 8
+	diplomacy = 5
+	intrigue = 8
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = greedy
+	trait = temperate
+	trait = amateurish_plotter
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224035 = {
+	name = "Abdul-Fattah"
+	# AKA: Abdul
+	dynasty = 100825
+	martial = 4
+	diplomacy = 8
+	intrigue = 8
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = proud
+	trait = martial_cleric
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224036 = {
+	name = "Abdul-Hamid"
+	# AKA: Abdul
+	dynasty = 100824
+	martial = 4
+	diplomacy = 5
+	intrigue = 6
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = thrifty_clerk
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224037 = {
+	name = "Sa'daddin"
+	dynasty = 100828
+	martial = 8
+	diplomacy = 4
+	intrigue = 8
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = scholarly_theologian
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224038 = {
+	name = "Hashmaddin"
+	dynasty = 100829
+	martial = 5
+	diplomacy = 8
+	intrigue = 8
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = kind
+	trait = gluttonous
+	trait = skilled_tactician
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224039 = {
+	name = "Jawhar"
+	dynasty = 100830
+	martial = 6
+	diplomacy = 5
+	intrigue = 8
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224040 = {
+	name = "Abdul-Gafur"
+	# AKA: Abdul
+	dynasty = 100831
+	martial = 4
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = patient
+	trait = martial_cleric
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224041 = {
+	name = "Ra'uf"
+	dynasty = 100832
+	martial = 7
+	diplomacy = 5
+	intrigue = 4
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = honest
+	trait = envious
+	trait = stutter
+	trait = tough_soldier
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224042 = {
+	name = "Jawhar"
+	dynasty = 100833
+	martial = 6
+	diplomacy = 6
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = lustful
+	trait = diligent
+	trait = envious
+	trait = proud
+	trait = tough_soldier
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224043 = {
+	name = "Abdul-Kareem"
+	# AKA: Abdul
+	dynasty = 100834
+	martial = 4
+	diplomacy = 7
+	intrigue = 4
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = just
+	trait = thrifty_clerk
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224044 = {
+	name = "Jawdat"
+	dynasty = 100835
+	martial = 6
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = diligent
+	trait = just
+	trait = cynical
+	trait = stutter
+	trait = skilled_tactician
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224045 = {
+	name = "Haroun"
+	dynasty = 100836
+	martial = 5
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = arbitrary
+	trait = skilled_tactician
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224046 = {
+	name = "Akab"
+	dynasty = 100837
+	martial = 5
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = zealous
+	trait = skilled_tactician
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+224047 = {
+	name = "Zeyd"
+	dynasty = 100838
+	martial = 8
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = deceitful
+	trait = amateurish_plotter
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+#226039 = {
+#	name = "Sulayman"
+#	dynasty = 100808
+#	martial = 8
+#	diplomacy = 5
+#	intrigue = 5
+#	stewardship = 4
+#	religion = sunni
+#	culture = maghreb_arabic
+#	trait = lustful
+#	trait = scholarly_theologian
+#	1150.1.1 = {
+#		birth = yes
+#	}
+#	1200.1.1 = {
+#		death = yes
+#	}
+#}
+
+226042 = {
+	name = "Sa'id"
+	dynasty = 100805
+	martial = 8
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = underhanded_rogue
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226043 = {
+	name = "Musa"
+	dynasty = 100806
+	martial = 7
+	diplomacy = 4
+	intrigue = 6
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = honest
+	trait = martial_cleric
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226044 = {
+	name = "Haroun"
+	dynasty = 100807
+	martial = 5
+	diplomacy = 6
+	intrigue = 4
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = amateurish_plotter
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226045 = {
+	name = "Abdul-Salaam"
+	# AKA: Abdul
+	dynasty = 100814
+	martial = 4
+	diplomacy = 8
+	intrigue = 4
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = just
+	trait = proud
+	trait = scholarly_theologian
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226046 = {
+	name = "Idris"
+	dynasty = 100809
+	martial = 6
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226047 = {
+	name = "Yasar"
+	dynasty = 100810
+	martial = 8
+	diplomacy = 5
+	intrigue = 6
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = slothful
+	trait = patient
+	trait = amateurish_plotter
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226048 = {
+	name = "Seyfullah"
+	dynasty = 100811
+	martial = 8
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = flamboyant_schemer
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226049 = {
+	name = "Abdul-Lateef"
+	# AKA: Abdul
+	dynasty = 100813
+	martial = 4
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = flamboyant_schemer
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+226050 = {
+	name = "Al-Aziz Uthman"
+	# AKA: Al
+	dynasty = 24000
+	martial = 5
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = misguided_warrior
+	father = 226000
+	1171.1.1 = {
+		birth = yes
+	}
+	1221.1.1 = {
+		death = yes
+	}
+}
+
+3210 = {
+	name = "Ali" #Tunis 1116-1121
+	dynasty = 595
+	martial = 5
+	diplomacy = 3
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = honest
+	trait = cynical
+	trait = tough_soldier
+	father = 3906
+	1080.1.1 = {
+		birth = yes
+	}
+	1121.1.1 = {
+		death = yes
+	}
+}
+
+3211 = {
+	name = "Abdul-Hasan"
+	dynasty = 595
+	martial = 5
+	diplomacy = 3
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = flamboyant_schemer
+	father = 3210
+	1100.1.1 = {
+		birth = yes
+	}
+	1163.1.1 = {
+		death = yes
+	}
+}
+
+3906 = {
+	name = "Yahya" #Tunis 1108-1116
+	dynasty = 595
+	martial = 6
+	diplomacy = 6
+	intrigue = 8
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	father = 20825
+	1062.1.1 = {
+		birth = yes
+	}
+	1116.1.1 = {
+		death = yes
+	}
+}
+
+420842 = {
+	name = "Hussamaddin"
+	dynasty = 100848
+	martial = 5
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+45014 = {
+	name = "Zawi"
+	dynasty = 595
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	trait = just
+	trait = wroth
+	father = 20931
+	950.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		death = yes
+	}
+}
+
+45015 = {
+	name = "Habus"
+	dynasty = 595
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = charismatic_negotiator
+	father = 45017
+	978.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		death = yes
+	}
+}
+
+45016 = {
+	name = "Badis"
+	dynasty = 595
+	martial = 4
+	diplomacy = 5
+	intrigue = 9
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = charismatic_negotiator
+	trait = greedy
+	trait = arbitrary
+	father = 45015
+	1006.1.1 = {
+		birth = yes
+	}
+	1073.1.1 = {
+		death = yes
+	}
+}
+
+45017 = {
+	name = "Maksan"
+	dynasty = 595
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	father = 20931
+	952.1.1 = {
+		birth = yes
+	}
+	1018.1.1 = {
+		death = yes
+	}
+}
+
+45018 = {
+	name = "al-Qaid" #Alger 1028 - 1054
+	dynasty = 575
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = underhanded_rogue
+	father = 20936
+	985.1.1 = {
+		birth = yes
+	}
+	1054.1.1 = {
+		death = yes
+	}
+}
+
+45019 = {
+	name = "Yusuf"
+	dynasty = 575
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = underhanded_rogue
+	father = 20936
+	990.1.1 = {
+		birth = yes
+	}
+	1062.1.1 = {
+		death = yes
+	}
+}
+
+45020 = {
+	name = "Ouighlan" #Mahdia
+	dynasty = 575
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = underhanded_rogue
+	father = 20936
+	995.1.1 = {
+		birth = yes
+	}
+	1088.1.1 = {
+		death = yes
+	}
+}
+
+45021 = {
+	name = "Muhsin" #Alger 1054-1055
+	dynasty = 575
+	martial = 4
+	diplomacy = 4
+	intrigue = 2
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = amateurish_plotter
+	father = 45018
+	1005.1.1 = {
+		birth = yes
+	}
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+45022 = {
+	name = "Muhammad"
+	dynasty = 575
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	father = 20936
+	991.1.1 = {
+		birth = yes
+	}
+	1040.1.1 = {
+		death = yes
+	}
+}
+
+45023 = {
+	name = "Buluggin" #Alger 1055-1062
+	dynasty = 575
+	martial = 4
+	diplomacy = 4
+	intrigue = 6
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = elusive_shadow
+	trait = paranoid
+	trait = ambitious
+	father = 45022
+	1025.1.1 = {
+		birth = yes
+	}
+	1062.1.1 = {
+		death = yes
+	}
+}
+
+45024 = {
+	name = "al-Mansur" #Alger 1088-1105
+	dynasty = 575
+	martial = 5
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = diligent
+	trait = thrifty_clerk
+	father = 20834
+	1065.1.1 = {
+		birth = yes
+	}
+	1110.1.1 = {
+		death = yes
+	}
+}
+
+482000 = {
+	name = "Muawiyah"
+	dynasty = 100843
+	martial = 7
+	diplomacy = 4
+	intrigue = 8
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = arbitrary
+	trait = amateurish_plotter
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+482010 = {
+	name = "Ashraf"
+	dynasty = 100836
+	martial = 5
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = scholarly_theologian
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+482020 = {
+	name = "Akab"
+	dynasty = 100837
+	martial = 5
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = chaste
+	trait = amateurish_plotter
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+482030 = {
+	name = "Ubayd"
+	dynasty = 100838
+	martial = 8
+	diplomacy = 8
+	intrigue = 4
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = just
+	trait = brave
+	trait = skilled_tactician
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+482040 = {
+	name = "Salahaddin"
+	dynasty = 100839
+	martial = 8
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = brave
+	trait = lisp
+	trait = fortune_builder
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+482050 = {
+	name = "Kerameddin"
+	dynasty = 100841
+	martial = 6
+	diplomacy = 4
+	intrigue = 7
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = arbitrary
+	trait = tough_soldier
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483000 = {
+	name = "Jamal"
+	dynasty = 100817
+	martial = 6
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = proud
+	trait = cynical
+	trait = flamboyant_schemer
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483010 = {
+	name = "Adnan"
+	dynasty = 100809
+	martial = 5
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = flamboyant_schemer
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483020 = {
+	name = "Yahya"
+	dynasty = 100810
+	martial = 8
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = scholarly_theologian
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483030 = {
+	name = "Abdul-Gafur"
+	# AKA: Abdul
+	dynasty = 100811
+	martial = 4
+	diplomacy = 7
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = hunchback
+	trait = tough_soldier
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483040 = {
+	name = "Abdul-Azeem"
+	# AKA: Abdul
+	dynasty = 100813
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = amateurish_plotter
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483050 = {
+	name = "Abdul-Wahab"
+	# AKA: Abdul
+	dynasty = 100814
+	martial = 4
+	diplomacy = 4
+	intrigue = 8
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483060 = {
+	name = "Sa'daddin"
+	dynasty = 100815
+	martial = 7
+	diplomacy = 8
+	intrigue = 6
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = greedy
+	trait = patient
+	trait = flamboyant_schemer
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483070 = {
+	name = "Yahya"
+	dynasty = 100816
+	martial = 8
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = flamboyant_schemer
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483080 = {
+	name = "Imamaddin"
+	dynasty = 100818
+	martial = 6
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = charitable
+	trait = envious
+	trait = underhanded_rogue
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483090 = {
+	name = "Giyasaddin"
+	dynasty = 100819
+	martial = 5
+	diplomacy = 4
+	intrigue = 6
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = amateurish_plotter
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483100 = {
+	name = "Sa'daddin"
+	dynasty = 100820
+	martial = 8
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = charitable
+	trait = cynical
+	trait = tough_soldier
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483110 = {
+	name = "Abdul-Jabbar"
+	# AKA: Abdul
+	dynasty = 100821
+	martial = 4
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = scholarly_theologian
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+483120 = {
+	name = "Tayyib"
+	dynasty = 100822
+	martial = 8
+	diplomacy = 5
+	intrigue = 4
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = slothful
+	trait = patient
+	trait = clubfooted
+	trait = thrifty_clerk
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484000 = {
+	name = "Zakariah"
+	dynasty = 100834
+	martial = 8
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = wroth
+	trait = cynical
+	trait = martial_cleric
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484010 = {
+	name = "Shamsaddin"
+	dynasty = 100835
+	martial = 8
+	diplomacy = 4
+	intrigue = 6
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = arbitrary
+	trait = underhanded_rogue
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484020 = {
+	name = "Ibrahim"
+	dynasty = 100823
+	martial = 6
+	diplomacy = 5
+	intrigue = 6
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = flamboyant_schemer
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484030 = {
+	name = "Badraddin"
+	dynasty = 100825
+	martial = 5
+	diplomacy = 6
+	intrigue = 4
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = humble
+	trait = wroth
+	trait = amateurish_plotter
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484040 = {
+	name = "Mustafa"
+	dynasty = 100824
+	martial = 7
+	diplomacy = 5
+	intrigue = 6
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = patient
+	trait = gluttonous
+	trait = flamboyant_schemer
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484050 = {
+	name = "Abdul-Wahab"
+	# AKA: Abdul
+	dynasty = 100828
+	martial = 4
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = honest
+	trait = hunchback
+	trait = tough_soldier
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484060 = {
+	name = "Muawiyah"
+	dynasty = 100829
+	martial = 7
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = humble
+	trait = flamboyant_schemer
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484070 = {
+	name = "Abdul-Malik"
+	# AKA: Abdul
+	dynasty = 100830
+	martial = 4
+	diplomacy = 8
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = charitable
+	trait = amateurish_plotter
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484080 = {
+	name = "Abdul-Lateef"
+	# AKA: Abdul
+	dynasty = 100831
+	martial = 4
+	diplomacy = 7
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	trait = zealous
+	trait = scholarly_theologian
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484090 = {
+	name = "Hashmaddin"
+	dynasty = 100832
+	martial = 5
+	diplomacy = 8
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = wroth
+	trait = harelip
+	trait = martial_cleric
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+484100 = {
+	name = "Adam"
+	dynasty = 100833
+	martial = 5
+	diplomacy = 4
+	intrigue = 6
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = gluttonous
+	trait = martial_cleric
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+485130 = {
+	name = "Musa"
+	dynasty = 100722
+	martial = 7
+	diplomacy = 7
+	intrigue = 6
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = just
+	trait = zealous
+	trait = tough_soldier
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+485140 = {
+	name = "Giyasaddin"
+	dynasty = 100723
+	martial = 5
+	diplomacy = 6
+	intrigue = 8
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = humble
+	trait = cynical
+	trait = martial_cleric
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+485150 = {
+	name = "Ya'qub"
+	dynasty = 100725
+	martial = 8
+	diplomacy = 5
+	intrigue = 4
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = ill
+	trait = fortune_builder
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+85007 = {
+	name = "Ifni"
+	dynasty = 595
+	martial = 3
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = thrifty_clerk
+	father = 20934
+	1002.1.1 = {
+		birth = yes
+	}
+	1060.1.1 = {
+		death = yes
+	}
+}
+
+32991 = {
+	name = "Buluggin"
+	dynasty = 595
+
+	father = 45016
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	1038.1.1 = {
+		birth = yes
+	}
+	1054.1.1 = {
+		add_spouse = 200235
+	}
+	1065.1.1 = {
+		death = yes
+	}
+}
+
+32951 = {
+	name = "Tamim"
+	dynasty = 595
+
+	father = 32991
+	mother = 200235
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	1055.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+32952 = {
+	name = "Abdallah"
+	dynasty = 595
+
+	father = 32991
+	mother = 200235
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	1057.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		add_claim = d_granada
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+32953 = {
+	name = "Abu-Yakni" #Constantine
+	dynasty = 575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 45021
+	1045.1.1 = {
+		birth = yes
+	}
+	1094.1.1 = {
+		death = yes
+	}
+}
+
+32954 = {
+	name = "Badis" #Alger 1105-1106
+	dynasty = 575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 45024
+	1085.1.1 = {
+		birth = yes
+	}
+	1106.1.1 = {
+		death = yes
+	}
+}
+
+32955 = {
+	name = "Abd-al-Aziz" #Alger 1106-1121
+	dynasty = 575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 45024
+	1090.1.1 = {
+		birth = yes
+	}
+	1121.1.1 = {
+		death = yes
+	}
+}
+
+32956 = {
+	name = "Yahya" #Alger 1121-1152
+	dynasty = 575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 45024
+	1110.1.1 = {
+		birth = yes
+	}
+	1163.1.1 = {
+		death = yes
+	}
+}
+
+32957 = {
+	name = "Umar"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32963
+	998.1.1 = {
+		birth = yes
+	}
+	1051.1.1 = {
+		death = yes
+	}
+}
+
+32958 = {
+	name = "Yahya" #Mauretania 1055-1057
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32957
+	1032.1.1 = {
+		birth = yes
+	}
+	1057.1.1 = {
+		death = yes
+	}
+}
+
+32962 = {
+	name = "Tashfin"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32963
+	1016.1.1 = {
+		birth = yes
+	}
+	1054.1.1 = {
+		death = yes
+	}
+}
+
+32963 = {
+	name = "Ibrahim"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155077
+	980.1.1 = {
+		birth = yes
+	}
+	1025.1.1 = {
+		death = yes
+	}
+}
+
+32964 = {
+	name = "Yahya" #Mauretania 1051-1055
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32963
+	1000.1.1 = {
+		birth = yes
+	}
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+32965 = {
+	name = "Yusuf" #Mauretania 1071-1106
+	dynasty = 7274
+	martial = 9
+	diplomacy = 8
+	intrigue = 5
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32962
+	trait = zealous
+	trait = diligent
+	trait = brave
+	trait = deceitful
+	trait = proud
+	trait = skilled_tactician
+	1040.1.1 = {
+		birth = yes
+	}
+	1060.1.1 = {
+		add_claim = k_mauretania
+		add_claim = d_tangiers
+		add_claim = d_fes
+		add_claim = d_tlemcen
+	}
+	1071.1.1 = {
+		add_spouse = 3856
+		add_claim = d_sevilla
+		add_claim = d_granada
+		add_claim = d_murcia
+		remove_claim = k_mauretania
+		create_bloodline = {
+			type = almoravid
+			has_dlc = "Holy Fury"
+		}
+	}
+	1078.10.8 = {
+		add_claim = d_zaragoza
+		add_claim = d_valencia
+		add_claim = d_mallorca
+		add_claim = d_murcia
+		add_claim = d_toledo
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1106.1.1 = {
+		death = yes
+	}
+}
+
+32966 = {
+	name = "al-Mu'izz"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32965
+	mother = 3856
+	1072.1.1 = {
+		birth = yes
+	}
+
+	1122.1.1 = {
+		death = yes
+	}
+}
+
+32967 = {
+	name = "Fadl"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32965
+	mother = 3856
+	1075.1.1 = {
+		birth = yes
+	}
+
+	1125.1.1 = {
+		death = yes
+	}
+}
+
+32968 = {
+	name = "Abu-Bakr"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32965
+	1060.1.1 = {
+		birth = yes
+	}
+
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+32969 = {
+	name = "Ali" #Mauretania 1106-1143
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32965
+	1080.1.1 = {
+		birth = yes
+	}
+
+	1143.1.1 = {
+		death = yes
+	}
+}
+
+32970 = {
+	name = "Ishaq" #Mauretania 1145-1147
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32969
+	1100.1.1 = {
+		birth = yes
+	}
+
+	1147.1.1 = {
+		death = yes
+	}
+}
+
+32971 = {
+	name = "Tashfin" #Mauretania 1143-1145
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32969
+	1103.1.1 = {
+		birth = yes
+	}
+
+	1145.1.1 = {
+		death = yes
+	}
+}
+
+32972 = {
+	name = "Ibrahim" #Mauretania 1145-1145
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32971
+	1135.1.1 = {
+		birth = yes
+	}
+	1146.1.1 = {
+		death = yes
+	}
+}
+
+32973 = {
+	name = "Muhammad"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155071
+	1110.1.1 = {
+		birth = yes
+	}
+	1126.1.1 = {
+		add_claim = d_valencia
+		add_claim = d_murcia
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1147.1.1 = {
+		add_claim = k_mauretania
+		add_claim = d_fes
+	}
+	1155.1.1 = {
+		death = yes
+	}
+}
+
+32974 = {
+	name = "Ishaq"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32973
+	1127.1.1 = {
+		birth = yes
+	}
+	1155.1.1 = {
+		add_claim = d_valencia
+		add_claim = d_murcia
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+		add_claim = k_mauretania
+		add_claim = d_fes
+	}
+	1183.1.1 = {
+		death = yes
+	}
+}
+
+32975 = {
+	name = "Muhammad"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32974
+	1146.1.1 = {
+		birth = yes
+	}
+	1183.1.1 = {
+		add_claim = d_valencia
+		add_claim = d_murcia
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1184.1.1 = {
+		add_claim = d_mallorca
+	}
+	1185.1.1 = {
+		remove_claim = d_mallorca
+	}
+	1186.1.1 = {
+		add_claim = d_mallorca
+	}
+	1202.1.1 = {
+		death = yes
+	}
+}
+
+32976 = {
+	name = "Ali"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32974
+	1147.1.1 = {
+		birth = yes
+	}
+	1183.1.1 = {
+		add_claim = d_mallorca
+		add_claim = k_mauretania
+		add_claim = d_fes
+	}
+	1184.1.1 = {
+		add_claim = d_valencia
+		add_claim = d_murcia
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1188.1.1 = {
+		death = yes
+	}
+}
+
+32977 = {
+	name = "Yahya"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32974
+	1148.1.1 = {
+		birth = yes
+	}
+	1184.1.1 = {
+		add_claim = d_kabylia
+		add_claim = d_tunis
+	}
+	1233.1.1 = {
+		death = yes
+	}
+}
+
+32978 = {
+	name = "Abd-al-Mu'min" #Mauretania 1147-1163
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	1094.1.1 = {
+		birth = yes
+	}
+	1094.1.1 = {
+		add_claim = k_mauretania
+		add_claim = d_tangiers
+		add_claim = d_fes
+		add_claim = d_kabylia
+		add_claim = k_africa
+		add_claim = d_tunis
+		add_claim = d_tripolitania
+		add_claim = d_zaragoza
+		add_claim = d_valencia
+		add_claim = d_mallorca
+		add_claim = d_murcia
+		add_claim = d_toledo
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1146.1.1 = {
+		remove_claim = d_tangiers
+		remove_claim = d_fes
+	}
+	1147.1.1 = {
+		remove_claim = k_mauretania
+	}
+	1163.1.1 = {
+		death = yes
+	}
+}
+
+32979 = {
+	name = "Muhammed"
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32978
+	1110.1.1 = {
+		birth = yes
+	}
+	1163.1.1 = {
+		death = yes
+	}
+}
+
+32980 = {
+	name = "Abu Ya'qub" #1184-1199
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 224000
+	1155.1.1 = {
+		birth = yes
+	}
+	1184.7.29 = {
+		create_bloodline = {
+			type = almohad
+			has_dlc = "Holy Fury"
+		}
+	}
+	1199.1.23 = {
+		death = yes
+	}
+}
+
+32981 = {
+	name = "Yusuf" #1213-1224
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 224005
+	1197.1.1 = {
+		birth = yes
+	}
+	1224.1.1 = {
+		death = yes
+	}
+}
+
+32982 = {
+	name = "Abdul-Wahid" #1224
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32981
+	1217.1.1 = {
+		birth = yes
+	}
+	1225.1.1 = {
+		death = yes
+	}
+}
+
+32983 = {
+	name = "Abdallah" #1225-1227
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32980
+	1175.1.1 = {
+		birth = yes
+	}
+	1227.1.1 = {
+		death = yes
+	}
+}
+
+32984 = {
+	name = "Yahya" #1227-1229
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 224005
+	1195.1.1 = {
+		birth = yes
+	}
+	1229.1.1 = {
+		death = yes
+	}
+}
+
+32985 = {
+	name = "Idris" #1229-1233
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32980
+	1174.1.1 = {
+		birth = yes
+	}
+	1233.1.1 = {
+		death = yes
+	}
+}
+
+32986 = {
+	name = "Abdul-Wahid" #1233-1242
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32985
+	1200.1.1 = {
+		birth = yes
+	}
+	1242.1.1 = {
+		death = yes
+	}
+}
+
+32987 = {
+	name = "Ali" #1242-1248
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32985
+	1199.1.1 = {
+		birth = yes
+	}
+	1248.1.1 = {
+		death = yes
+	}
+}
+
+32988 = {
+	name = "Ishaq"
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32980
+	1180.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+32989 = {
+	name = "Umar" #1248-1266
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32988
+	1210.1.1 = {
+		birth = yes
+	}
+	1266.1.1 = {
+		death = yes
+	}
+}
+
+32990 = {
+	name = "Idris" #1266-1269
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32989
+	1240.1.1 = {
+		birth = yes
+	}
+	1269.1.1 = {
+		death = yes
+	}
+}
+
+32992 = {
+	name = "Mussa"
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32980
+	1173.1.1 = {
+		birth = yes
+	}
+	1223.1.1 = {
+		death = yes
+	}
+}
+
+32993 = {
+	name = "Abd-al-Haqq" #Fez 1212-1217
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	1167.1.1 = {
+		birth = yes
+	}
+	1212.7.16 = {
+		add_claim = k_mauretania
+		add_claim = d_tangiers
+		add_claim = d_fes
+	}
+	1217.1.1 = {
+		death = yes
+	}
+}
+
+32994 = {
+	name = "Uthman" #Fez 1217-1240
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32993
+	1190.1.1 = {
+		birth = yes
+	}
+	1217.1.1 = {
+		add_claim = k_mauretania
+		add_claim = d_tangiers
+		add_claim = d_fes
+	}
+	1240.1.1 = {
+		death = yes
+	}
+}
+
+32995 = {
+	name = "Muhammed" #Fez 1240-1244
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32993
+	1192.1.1 = {
+		birth = yes
+	}
+	1240.1.1 = {
+		add_claim = k_mauretania
+		add_claim = d_tangiers
+		add_claim = d_fes
+	}
+	1244.1.1 = {
+		death = yes
+	}
+}
+
+32996 = {
+	name = "Yahya" #Fez 1244-1258
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32993
+	1200.1.1 = {
+		birth = yes
+	}
+	1244.1.1 = {
+		add_claim = k_mauretania
+		add_claim = d_tangiers
+		add_claim = d_fes
+	}
+	1258.1.1 = {
+		death = yes
+	}
+}
+
+32997 = {
+	name = "Yusuf" #Fez 1258-1286, Mauretania 1269-1286
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32993
+	1210.1.1 = {
+		birth = yes
+	}
+	1258.1.1 = {
+		add_claim = k_mauretania
+		add_claim = d_tangiers
+	}
+	1269.1.1 = {
+		add_claim = d_tlemcen
+		remove_claim = k_mauretania
+	}
+	1286.3.20 = {
+		death = yes
+	}
+}
+
+32998 = {
+	name = "Ya'qub" #Mauretania 1286-1307
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32997
+	1240.1.1 = {
+		birth = yes
+	}
+	1286.3.20 = {
+		add_claim = d_tlemcen
+	}
+	1307.5.13 = {
+		death = yes
+	}
+}
+
+32999 = {
+	name = "Amir"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32998
+	1258.1.1 = {
+		birth = yes
+	}
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+33000 = {
+	name = "Thabit" #1307-1308
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32999
+	1283.1.1 = {
+		birth = yes
+	}
+	1307.5.13 = {
+		add_claim = d_tlemcen
+	}
+	1308.7.28 = {
+		death = yes
+	}
+
+}
+
+33001 = {
+	name = "al-Rabi" #1308-1310
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32999
+	1291.1.1 = {
+		birth = yes
+	}
+	1308.7.28 = {
+		add_claim = d_tlemcen
+	}
+	1310.11.23 = {
+		death = yes
+	}
+
+}
+
+33002 = {
+	name = "Uthman" #1310-1331
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32998
+	1275.1.1 = {
+		birth = yes
+	}
+	1310.11.23 = {
+		add_claim = d_tlemcen
+	}
+	1331.8.1 = {
+		death = yes
+	}
+}
+
+33003 = {
+	name = "Ali"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33002
+	1294.1.1 = {
+		birth = yes
+	}
+	1332.1.1 = {
+		death = yes
+	}
+}
+
+33004 = {
+	name = "al-Hasan" #1331-1351
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32998
+	1297.1.1 = {
+		birth = yes
+	}
+	1331.8.1 = {
+		add_claim = d_tlemcen
+	}
+	1351.5.24 = {
+		death = yes
+	}
+}
+
+33005 = {
+	name = "al-Halein"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33002
+	1315.1.1 = {
+		birth = yes
+	}
+	1362.1.1 = {
+		death = yes
+	}
+}
+
+33006 = {
+	name = "Ali"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33004
+	1315.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+33007 = {
+	name = "Inan Faris"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33004
+	1329.1.1 = {
+		birth = yes
+	}
+	1358.1.1 = {
+		death = yes
+	}
+}
+
+33008 = {
+	name = "Muhammed"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33004
+	1331.1.1 = {
+		birth = yes
+	}
+	1387.1.1 = {
+		death = yes
+	}
+}
+
+33009 = {
+	name = "Ibrahim"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33004
+	1333.1.1 = {
+		birth = yes
+	}
+	1361.1.1 = {
+		death = yes
+	}
+}
+
+33010 = {
+	name = "Ya'qub"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33004
+	1335.1.1 = {
+		birth = yes
+	}
+	1366.1.1 = {
+		death = yes
+	}
+}
+
+33011 = {
+	name = "Faris"
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33004
+	1337.1.1 = {
+		birth = yes
+	}
+	1372.1.1 = {
+		death = yes
+	}
+}
+
+33012 = {
+	name = "Hafs-Umar"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	1105.1.1 = {
+		birth = yes
+	}
+	1176.1.1 = {
+		death = yes
+	}
+}
+
+33013 = {
+	name = "Othman"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33012
+	1144.1.1 = {
+		birth = yes
+	}
+	1204.1.1 = {
+		death = yes
+	}
+}
+
+33014 = {
+	name = "Abd-al-Wahid" #Tunis 1207-1224
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33012
+	1176.1.1 = {
+		birth = yes
+	}
+	1207.1.1 = {
+		add_claim = k_africa
+		add_claim = d_kabylia
+		add_claim = d_tripolitania
+	}
+	1224.1.1 = {
+		death = yes
+	}
+}
+
+33015 = {
+	name = "Ishaq"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33012
+	1156.1.1 = {
+		birth = yes
+	}
+	1220.1.1 = {
+		death = yes
+	}
+}
+
+33016 = {
+	name = "Abd-ar-Rahman"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33012
+	1158.1.1 = {
+		birth = yes
+	}
+	1223.1.1 = {
+		death = yes
+	}
+}
+
+33017 = {
+	name = "Abd-ar-Rahman" #Africa 1284-1295
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33016
+	1200.1.1 = {
+		birth = yes
+	}
+	1295.1.1 = {
+		death = yes
+	}
+}
+
+33018 = {
+	name = "Abu-Bakr"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33016
+	1201.1.1 = {
+		birth = yes
+	}
+	1251.1.1 = {
+		death = yes
+	}
+}
+
+33019 = {
+	name = "Abd-al-Ouahed"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33016
+	1202.1.1 = {
+		birth = yes
+	}
+	1252.1.1 = {
+		death = yes
+	}
+}
+
+33020 = {
+	name = "Abdallah" #Tunis 1224-1229
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33016
+	1203.1.1 = {
+		birth = yes
+	}
+	1224.1.1 = {
+		add_claim = k_africa
+		add_claim = d_kabylia
+		add_claim = d_tripolitania
+	}
+	1229.1.1 = {
+		death = yes
+	}
+}
+
+33021 = {
+	name = "Zakariya" #Africa 1229-1251
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33016
+	1204.1.1 = {
+		birth = yes
+	}
+	1229.1.1 = {
+		add_claim = d_tlemcen
+		add_claim = d_tripolitania
+	}
+	1251.1.1 = {
+		death = yes
+	}
+}
+
+33022 = {
+	name = "Abdallah"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33020
+	1220.1.1 = {
+		birth = yes
+	}
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+33023 = {
+	name = "Idris"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33020
+	1221.1.1 = {
+		birth = yes
+	}
+	1269.1.1 = {
+		death = yes
+	}
+}
+
+33024 = {
+	name = "Abdallah" #Africa 1251-1276
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33021
+	1221.1.1 = {
+		birth = yes
+	}
+	1276.1.1 = {
+		death = yes
+	}
+}
+
+33025 = {
+	name = "Ishaq" #Africa 1279-1284
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33021
+	1223.1.1 = {
+		birth = yes
+	}
+	1284.1.1 = {
+		death = yes
+	}
+}
+
+33026 = {
+	name = "Zakariya" #Africa 1276-1279
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33024
+	1240.1.1 = {
+		birth = yes
+	}
+	1279.1.1 = {
+		death = yes
+	}
+}
+
+33027 = {
+	name = "Muhammed" #Africa 1295-1309
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33026
+	1260.1.1 = {
+		birth = yes
+	}
+	1309.1.1 = {
+		death = yes
+	}
+}
+
+33028 = {
+	name = "Yahya" #Africa 1309
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33027
+	1290.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+33029 = {
+	name = "Zakariya"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33025
+	1243.1.1 = {
+		birth = yes
+	}
+	1293.1.1 = {
+		death = yes
+	}
+}
+
+33030 = {
+	name = "Zakariya"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33029
+	1260.1.1 = {
+		birth = yes
+	}
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+33031 = {
+	name = "Khalid" #Africa 1310-1311
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33029
+	1262.1.1 = {
+		birth = yes
+	}
+	1311.1.1 = {
+		death = yes
+	}
+}
+
+33032 = {
+	name = "Yahya" #Africa 1318-1346
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33029
+	1266.1.1 = {
+		birth = yes
+	}
+	1346.1.1 = {
+		death = yes
+	}
+}
+
+33033 = {
+	name = "Abdallah"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33029
+	1263.1.1 = {
+		birth = yes
+	}
+	1303.1.1 = {
+		death = yes
+	}
+}
+
+33034 = {
+	name = "Ishaq"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33032
+	1300.1.1 = {
+		birth = yes
+	}
+	1369.1.1 = {
+		death = yes
+	}
+}
+
+33035 = {
+	name = "Umar"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33032
+	1302.1.1 = {
+		birth = yes
+	}
+	1349.1.1 = {
+		death = yes
+	}
+}
+
+33036 = {
+	name = "Abdallah"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33032
+	1304.1.1 = {
+		birth = yes
+	}
+	1354.1.1 = {
+		death = yes
+	}
+}
+
+33037 = {
+	name = "Khalid"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33034
+	1321.1.1 = {
+		birth = yes
+	}
+	1371.1.1 = {
+		death = yes
+	}
+}
+
+33038 = {
+	name = "al-Mutawakki"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33035
+	1329.1.1 = {
+		birth = yes
+	}
+	1346.1.1 = {
+		death = yes
+	}
+}
+
+33039 = {
+	name = "al-Mustansir"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33035
+	1333.1.1 = {
+		birth = yes
+	}
+	1394.1.1 = {
+		death = yes
+	}
+}
+
+33040 = {
+	name = "Muhammed"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33019
+	1220.1.1 = {
+		birth = yes
+	}
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+33041 = {
+	name = "Ahmad"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33040
+	1240.1.1 = {
+		birth = yes
+	}
+	1290.1.1 = {
+		death = yes
+	}
+}
+
+33042 = {
+	name = "Yahya" #Africa 1311-1317
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33041
+	1270.1.1 = {
+		birth = yes
+	}
+	1317.1.1 = {
+		death = yes
+	}
+}
+
+33043 = {
+	name = "Muhammed" #Africa 1317-1318
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33042
+	1300.1.1 = {
+		birth = yes
+	}
+	1318.1.1 = {
+		death = yes
+	}
+}
+
+33044 = {
+	name = "Zyan"
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	1180.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+33045 = {
+	name = "Yghomracen" #Alger 1229-1283
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33044
+	1210.1.1 = {
+		birth = yes
+	}
+	1283.1.1 = {
+		death = yes
+	}
+}
+
+33046 = {
+	name = "Othman" #Alger 1283-1304
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33045
+	1250.1.1 = {
+		birth = yes
+	}
+	1304.1.1 = {
+		death = yes
+	}
+}
+
+33047 = {
+	name = "Zyan" #Alger 1304-1308
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33046
+	1280.1.1 = {
+		birth = yes
+	}
+	1308.1.1 = {
+		death = yes
+	}
+}
+
+33048 = {
+	name = "Hammu" #Alger 1308-1318
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33046
+	1285.1.1 = {
+		birth = yes
+	}
+	1318.1.1 = {
+		death = yes
+	}
+}
+
+33049 = {
+	name = "Tashfin" #Alger 1318-1337
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33048
+	1305.1.1 = {
+		birth = yes
+	}
+	1337.2.1 = {
+		death = yes
+	}
+}
+
+33050 = {
+	name = "Othman"
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33049
+	1332.1.1 = {
+		birth = yes
+	}
+	1352.1.1 = {
+		death = yes
+	}
+}
+
+33051 = {
+	name = "Thabit"
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33049
+	1333.1.1 = {
+		birth = yes
+	}
+	1352.1.1 = {
+		death = yes
+	}
+}
+
+33052 = {
+	name = "Hammu"
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33049
+	1335.1.1 = {
+		birth = yes
+	}
+	1389.1.1 = {
+		death = yes
+	}
+}
+
+3853 = {
+	name = "Abu-Bakr"
+	# AKA: Abu Bakr
+	dynasty = 7274
+	martial = 10
+	diplomacy = 7
+	intrigue = 4
+	stewardship = 4
+	religion = sunni
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	trait = patient
+	trait = just
+	trait = diligent
+	trait = zealous
+	father = 32957
+	1036.1.1 = {
+		birth = yes
+	}
+	1052.1.1 = {
+		add_spouse = 273120
+	}
+	1060.1.1 = {
+		add_claim = d_tangiers
+		add_claim = d_fes
+		add_claim = d_tlemcen
+		add_claim = d_sevilla
+		add_claim = d_granada
+		add_claim = d_murcia
+	}
+	1068.1.1 = {
+		add_spouse = 3856
+	}
+	1071.1.1 = {
+		remove_spouse = 3856
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+3855 = {
+	name = "Ismail"
+	dynasty = 7274
+	martial = 7
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = tough_soldier
+	father = 3853
+	1057.1.1 = {
+		birth = yes
+	}
+	1107.1.1 = {
+		death = yes
+	}
+}
+
+3856 = {
+	name = "Zainab"
+	dynasty = 7275
+	female = yes
+	martial = 5
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = amateurish_plotter
+	1040.1.2 = {
+		birth = yes
+	}
+	1090.1.2 = {
+		death = yes
+	}
+}
+
+224000 = {
+	name = "Yusuf" #1163-1184
+	# AKA: Abu Yusuf Ya'qub
+	dynasty = 101875
+	martial = 7
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 8
+	religion = sunni
+	culture = maghreb_arabic
+	trait = just
+	trait = tough_soldier
+	father = 32978
+	1135.1.1 = {
+		birth = yes
+	}
+	1184.7.29 = {
+		death = yes
+	}
+}
+
+224005 = {
+	name = "an-Nassir" #1199-1213
+	dynasty = 101875
+	martial = 4
+	diplomacy = 5
+	intrigue = 4
+	stewardship = 5
+	religion = sunni
+	culture = maghreb_arabic
+	trait = stutter
+	trait = tough_soldier
+	father = 32980
+	1176.1.1 = {
+		birth = yes
+	}
+	1213.1.1 = {
+		death = yes
+	}
+}
+
+73219 = {
+	name = "Muhammad"
+	dynasty = 101700
+	religion = sunni
+	culture = maghreb_arabic
+	973.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+73220 = {
+	name = "Abdun"
+	dynasty = 101700
+	religion = sunni
+	culture = maghreb_arabic
+	father = 73219
+	999.1.1 = {
+		birth = yes
+	}
+	1053.1.1 = {
+		death = yes
+	}
+}
+
+73221 = {
+	name = "Muhammad"
+	dynasty = 101700
+	religion = sunni
+	culture = maghreb_arabic
+	father = 73219
+	1003.1.1 = {
+		birth = yes
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+73222 = {
+	name = "Sïr"
+	dynasty = 12200
+	religion = sunni
+	culture = maghreb_arabic
+	1048.1.1 = {
+		birth = yes
+	}
+	1114.1.1 = {
+		death = yes
+	}
+}
+
+73229 = {
+	name = "Wanur"
+	dynasty = 12203
+	religion = sunni
+	culture = maghreb_arabic
+	1072.1.1 = {
+		birth = yes
+	}
+	1126.1.1 = {
+		death = yes
+	}
+}
+
+73230 = {
+	name = "Tashfin"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32974
+	1149.1.1 = {
+		birth = yes
+	}
+	1184.1.1 = {
+		add_claim = d_mallorca
+	}
+	1186.1.1 = {
+		remove_claim = d_mallorca
+		add_claim = d_valencia
+		add_claim = d_murcia
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1187.1.1 = {
+		add_claim = d_mallorca
+	}
+	1202.1.1 = {
+		death = yes
+	}
+}
+
+73231 = {
+	name = "Abdallah"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32974
+	1150.1.1 = {
+		birth = yes
+	}
+	1187.1.1 = {
+		add_claim = d_valencia
+		add_claim = d_murcia
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1203.1.1 = {
+		add_claim = d_mallorca
+	}
+	1208.1.1 = {
+		death = yes
+	}
+}
+
+73232 = {
+	name = "Sa'd"
+	dynasty = 7279
+	religion = shiite
+	culture = maghreb_arabic
+	father = 33057
+	1252.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+73233 = {
+	name = "Abdallah"
+	dynasty = 12207
+	religion = shiite
+	culture = maghreb_arabic
+	1154.1.1 = {
+		birth = yes
+	}
+	1208.1.1 = {
+		death = yes
+	}
+}
+
+73234 = {
+	name = "Hakam"
+	dynasty = 7279
+	religion = shiite
+	culture = maghreb_arabic
+	father = 33056
+	1204.1.1 = {
+		birth = yes
+	}
+	1242.1.1 = {
+		add_claim = d_murcia
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1248.1.1 = {
+		remove_claim = d_sevilla
+	}
+	1249.1.1 = {
+		remove_claim = d_murcia
+	}
+	1263.1.1 = {
+		death = yes
+	}
+}
+
+33056 = {
+	name = "Sa'd"
+	dynasty = 7279
+	religion = shiite
+	culture = maghreb_arabic
+	1176.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		add_claim = d_valencia
+		add_claim = d_murcia
+		add_claim = d_cordoba
+		add_claim = d_badajoz
+		add_claim = d_sevilla
+		add_claim = d_granada
+	}
+	1230.3.19 = {
+		remove_claim = d_badajoz
+	}
+	1236.1.1 = {
+		remove_claim = d_valencia
+		remove_claim = d_cordoba
+	}
+	1242.1.1 = {
+		death = yes
+	}
+}
+
+33057 = {
+	name = "Umar"
+	dynasty = 7279
+	religion = shiite
+	culture = maghreb_arabic
+	father = 73234
+	1228.1.1 = {
+		birth = yes
+	}
+	1263.1.1 = {
+		add_claim = d_granada
+	}
+	1287.1.1 = {
+		death = yes
+	}
+}
+
+224001 = {
+	name = "Abd-al-Razzaq"
+	dynasty = 12225
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	1126.1.1 = {
+		birth = yes
+	}
+	1189.1.1 = {
+		death = yes
+	}
+}
+
+224010 = {
+	name = "Abd-al-Aziz"
+	dynasty = 12218
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	1133.1.1 = {
+		birth = yes
+	}
+	1188.1.1 = {
+		death = yes
+	}
+}
+
+224013 = {
+	name = "Yahya"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	trait = patient
+	trait = flamboyant_schemer
+	father = 32965
+	1080.1.1 = {
+		birth = yes
+	}
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+224015 = {
+	name = "Ya'qub"
+	dynasty = 12233
+	martial = 5
+	diplomacy = 6
+	intrigue = 4
+	stewardship = 7
+	religion = shiite
+	culture = maghreb_arabic
+	trait = patient
+	trait = tough_soldier
+	1121.1.1 = {
+		birth = yes
+	}
+	1178.1.1 = {
+		death = yes
+	}
+}
+
+224020 = {
+	name = "Muhammad"
+	dynasty = 12220
+	martial = 7
+	diplomacy = 7
+	intrigue = 8
+	stewardship = 8
+	religion = shiite
+	culture = maghreb_arabic
+	trait = just
+	trait = proud
+	trait = honest
+	trait = amateurish_plotter
+	1128.1.1 = {
+		birth = yes
+	}
+	1190.1.1 = {
+		death = yes
+	}
+}
+
+224022 = {
+	name = "Muhammad"
+	dynasty = 12222
+	martial = 6
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 8
+	religion = shiite
+	culture = maghreb_arabic
+	trait = skilled_tactician
+	1112.1.1 = {
+		birth = yes
+	}
+	1169.1.1 = {
+		death = yes
+	}
+}
+
+224009 = {
+	name = "Abd-al-Aziz"
+	dynasty = 12217
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	1119.1.1 = {
+		birth = yes
+	}
+	1172.1.1 = {
+		death = yes
+	}
+}
+
+224011 = {
+	name = "Yazid"
+	dynasty = 12219
+	martial = 8
+	diplomacy = 5
+	intrigue = 8
+	stewardship = 8
+	religion = shiite
+	culture = maghreb_arabic
+	trait = tough_soldier
+	1127.1.1 = {
+		birth = yes
+	}
+	1188.1.1 = {
+		death = yes
+	}
+}
+
+224021 = {
+	name = "Bilal"
+	dynasty = 12221
+	martial = 5
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 6
+	religion = shiite
+	culture = maghreb_arabic
+	trait = envious
+	trait = flamboyant_schemer
+	1146.1.1 = {
+		birth = yes
+	}
+	1199.1.1 = {
+		death = yes
+	}
+}
+
+20871 = {
+	name = "Muhammad"
+	dynasty = 12206
+	martial = 7
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 6
+	religion = shiite
+	culture = maghreb_arabic
+	trait = patient
+	trait = temperate
+	1179.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+73309 = {
+	name = "Muhammad"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159194
+	1030.1.1 = {
+		birth = yes
+	}
+	1071.1.1 = {
+		death = yes
+	}
+}
+
+73310 = {
+	name = "Abdallah"
+	dynasty = 12236
+	religion = sunni
+	culture = maghreb_arabic
+	1012.1.1 = {
+		birth = yes
+	}
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+73311 = {
+	name = "Hasan"
+	dynasty = 12238
+	religion = sunni
+	culture = maghreb_arabic
+	1030.1.1 = {
+		birth = yes
+	}
+	1069.1.1 = {
+		death = yes
+	}
+}
+
+73312 = {
+	name = "Ali"
+	dynasty = 12239
+	religion = sunni
+	culture = maghreb_arabic
+	1013.1.1 = {
+		birth = yes
+	}
+	1067.1.1 = {
+		death = yes
+	}
+}
+
+73313 = {
+	name = "Abdul-Qadir"
+	dynasty = 575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 45018
+	1010.1.1 = {
+		birth = yes
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+73314 = {
+	name = "Muhammad"
+	dynasty = 12241
+	religion = sunni
+	culture = maghreb_arabic
+	father = 20828
+	1065.1.1 = {
+		birth = yes
+	}
+	1120.1.1 = {
+		death = yes
+	}
+}
+
+73315 = {
+	name = "Abdallah"
+	dynasty = 12241
+	religion = sunni
+	culture = maghreb_arabic
+	father = 73314
+	1090.1.1 = {
+		birth = yes
+	}
+	1127.1.1 = {
+		death = yes
+	}
+}
+
+20828 = {
+	name = "Ramadan"
+	dynasty = 12241
+	martial = 7
+	diplomacy = 7
+	intrigue = 4
+	stewardship = 7
+	religion = sunni
+	culture = maghreb_arabic
+	1039.1.1 = {
+		birth = yes
+	}
+	1092.1.1 = {
+		death = yes
+	}
+}
+
+20831 = {
+	name = "Yusuf"
+	dynasty = 12236
+	religion = sunni
+	culture = maghreb_arabic
+	father = 73310
+	1035.1.1 = {
+		birth = yes
+	}
+	1071.1.1 = {
+		death = yes
+	}
+}
+
+20829 = {
+	name = "Abbad"
+	dynasty = 12237
+	martial = 8
+	diplomacy = 6
+	intrigue = 4
+	stewardship = 6
+	religion = sunni
+	culture = maghreb_arabic
+	trait = amateurish_plotter
+	1025.1.1 = {
+		birth = yes
+	}
+	1086.1.1 = {
+		death = yes
+	}
+}
+
+155000 = {
+	name = "Ibrahim"
+	dynasty = 1027003
+	religion = sunni
+	culture = maghreb_arabic
+	950.1.1 = {
+		birth = yes
+	}
+	1015.1.1 = {
+		death = yes
+	}
+}
+
+155001 = {
+	name = "abd-al-Rahman" #ibn Ibrahim
+	dynasty = 1027003
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155000
+	980.1.1 = {
+		birth = yes
+	}
+	1039.1.1 = {
+		death = yes
+	}
+}
+
+155002 = {
+	name = "Muhammad" #ibn abd-al-Rahman
+	dynasty = 1027003
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155001
+	1010.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		death = yes
+	}
+}
+
+155003 = {
+	name = "Qasim" #ibn Muhammad
+	dynasty = 1027003
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155002
+	1040.1.1 = {
+		birth = yes
+	}
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+155004 = {
+	name = "Muhammad"
+	dynasty = 1027006
+	religion = sunni #heretic?
+	culture = maghreb_arabic
+	970.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		death = yes
+	}
+}
+
+155005 = {
+	name = "Suqut" #ibn Muhammad
+	dynasty = 1027006
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155004
+	trait = tough_soldier
+	990.1.1 = {
+		birth = yes
+	}
+	1078.10.8 = {
+		death = yes #supposedly ~90!
+	}
+}
+
+155006 = {
+	name = "Diya'al-Dawla"
+	#al-Mu'izz-Diya'al-Dawla ibn Suqut
+	dynasty = 1027006
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155005
+	1060.1.1 = {
+		birth = yes
+	}
+	1083.7.1 = {
+		death = yes
+	}
+}
+
+155007 = {
+	name = "Yahya"
+	#placeholder
+	dynasty = 1027004
+	religion = sunni
+	culture = maghreb_arabic
+	1040.1.1 = {
+		birth = yes
+	}
+	1082.1.1 = {
+		death = yes
+	}
+}
+
+155008 = {
+	name = "al-Mu'izz" #ibn Ziri
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155121
+	970.1.1 = {
+		birth = yes
+	}
+	1026.1.1 = {
+		death = yes
+	}
+}
+
+155009 = {
+	name = "Hammama" #ibn al-Mu'izz
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155008
+	988.1.1 = {
+		birth = yes
+	}
+	1040.1.1 = {
+		death = yes
+	}
+}
+
+155010 = {
+	name = "Dunas" #ibn Hammama
+	#Abu-Attaf Dunas
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155009
+	1020.1.1 = {
+		birth = yes
+	}
+	1059.1.1 = {
+		death = yes
+	}
+}
+
+155011 = {
+	name = "al-Futuh" #ibn Dunas
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155010
+	1039.1.1 = {
+		birth = yes
+	}
+	1063.1.1 = {
+		death = yes
+	}
+}
+
+155012 = {
+	name = "Ajissa" #ibn Dunas
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155010
+	1041.1.1 = {
+		birth = yes
+	}
+	1061.1.1 = {
+		death = yes #Killed by al-Futuh
+	}
+}
+
+155013 = {
+	name = "Mu'ansir" #ibn al-Mu'izz
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155008
+	990.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+155014 = {
+	name = "Hammad" #ibn Mu'ansir
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155013
+	1010.1.1 = {
+		birth = yes
+	}
+	1043.1.1 = {
+		death = yes
+	}
+}
+
+155015 = {
+	name = "Mu'ansir" #ibn Hammad
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155014
+	1030.1.1 = {
+		birth = yes
+	}
+	1068.1.1 = {
+		death = yes
+	}
+}
+
+155016 = {
+	name = "Tamim" #ibn Mu'ansir
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155015
+	1050.1.1 = {
+		birth = yes
+	}
+	1070.3.18 = {
+		death = yes
+	}
+}
+
+155017 = {
+	name = "Bakhti"
+	dynasty = 1027002
+	religion = sunni
+	culture = maghreb_arabic
+	1020.1.1 = {
+		birth = yes
+	}
+	1060.1.1 = {
+		death = yes
+	}
+}
+
+155018 = {
+	name = "al-'Abbas" #ibn Bakhti
+	dynasty = 1027002
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155017
+	1040.1.1 = {
+		birth = yes
+	}
+	1082.1.1 = {
+		death = yes
+	}
+}
+
+155019 = {
+	name = "Mali" #ibn al-'Abbas
+	dynasty = 1027002
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155018
+	1060.1.1 = {
+		birth = yes
+	}
+	1081.1.1 = {
+		death = yes
+	}
+}
+
+155020 = {
+	name = "Shumayl"
+	#placeholder
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155009
+	1025.1.1 = {
+		birth = yes
+	}
+	1083.1.1 = {
+		death = yes
+	}
+}
+
+155021 = {
+	name = "Abu-'Amr"
+	#placeholder
+	dynasty = 1027000
+	religion = sunni
+	culture = maghreb_arabic
+	1045.1.1 = {
+		birth = yes
+	}
+	1109.1.1 = {
+		death = yes
+	}
+}
+
+155022 = {
+	name = "Wadih"
+	#placeholder
+	dynasty = 1027000
+	religion = sunni
+	culture = maghreb_arabic
+	1087.1.1 = {
+		birth = yes
+	}
+	1152.1.1 = {
+		death = yes
+	}
+}
+
+155023 = {
+	name = "Abdul-Razzaq"
+	#placeholder
+	dynasty = 1027009
+	religion = sunni
+	culture = maghreb_arabic
+	1030.1.1 = {
+		birth = yes
+	}
+	1083.1.1 = {
+		death = yes
+	}
+}
+
+155024 = {
+	name = "Abu-Sahl"
+	#placeholder
+	dynasty = 1027005
+	religion = sunni
+	culture = maghreb_arabic
+	1045.1.1 = {
+		birth = yes
+	}
+	1109.1.1 = {
+		death = yes
+	}
+}
+
+155025 = {
+	name = "Rashid"
+	#placeholder
+	dynasty = 1027005
+	religion = sunni
+	culture = maghreb_arabic
+	1087.1.1 = {
+		birth = yes
+	}
+	1152.1.1 = {
+		death = yes
+	}
+}
+
+155026 = {
+	name = "Shiruyah"
+	#placeholder
+	dynasty = 101733
+	religion = sunni
+	culture = maghreb_arabic
+	1045.1.1 = {
+		birth = yes
+	}
+	1109.1.1 = {
+		death = yes
+	}
+}
+
+155027 = {
+	name = "Hisham"
+	#placeholder
+	dynasty = 101733
+	religion = sunni
+	culture = maghreb_arabic
+	1087.1.1 = {
+		birth = yes
+	}
+	1152.1.1 = {
+		death = yes
+	}
+}
+
+155032 = {
+	name = "Sulayman"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155084
+	1000.1.1 = {
+		birth = yes
+	}
+	1060.1.1 = {
+		death = yes
+	}
+}
+
+155033 = {
+	name = "Umar" #ibn Sulayman
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155032
+	1040.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+155034 = {
+	name = "Tinaghmar"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155084
+	1010.1.1 = {
+		birth = yes
+	}
+	1060.1.1 = {
+		death = yes
+	}
+}
+
+155035 = {
+	name = "Muhammad" #ibn Tinaghmar
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155034
+	1045.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+155036 = {
+	name = "Syr" #ibn Abu-Bakr ibn Tashfin
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155076
+	1059.1.1 = {
+		birth = yes
+	}
+	1114.1.1 = {
+		death = yes
+	}
+}
+
+155037 = {
+	name = "Nusayr"
+	#placeholder
+	dynasty = 1027008
+	religion = sunni
+	culture = maghreb_arabic
+	1040.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+155038 = {
+	name = "Musaddid"
+	#placeholder
+	dynasty = 1027008
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155037
+	1060.1.1 = {
+		birth = yes
+	}
+	1110.1.1 = {
+		death = yes
+	}
+}
+
+155039 = {
+	name = "Abu-Hazim"
+	#placeholder
+	dynasty = 1027008
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155038
+	1080.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+155040 = {
+	name = "Abdul-Wahid"
+	#placeholder
+	dynasty = 1027008
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155039
+	1100.1.1 = {
+		birth = yes
+	}
+	1152.1.1 = {
+		death = yes
+	}
+}
+
+155041 = {
+	name = "al-'Urwah"
+	dynasty = 1027014
+	religion = sunni
+	culture = maghreb_arabic
+	1180.1.1 = {
+		birth = yes
+	}
+	1220.1.1 = {
+		death = yes
+	}
+}
+
+155042 = {
+	name = "Ali" #ibn al-'Urwah
+	dynasty = 1027014
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155041
+	1200.1.1 = {
+		birth = yes
+	}
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+155043 = {
+	name = "Talha" #ibn Ali
+	dynasty = 1027014
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155042
+	1235.1.1 = {
+		birth = yes
+	}
+	1295.1.1 = {
+		death = yes
+	}
+}
+
+155044 = {
+	name = "Yahya" #ibn Ali
+	dynasty = 1027014
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155042
+	1240.1.1 = {
+		birth = yes
+	}
+	1305.1.1 = {
+		death = yes
+	}
+}
+
+155045 = {
+	name = "Mendil" #ibn Ali
+	dynasty = 1027014
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155042
+	1265.1.1 = {
+		birth = yes
+	}
+	1340.1.1 = {
+		death = yes
+	}
+}
+
+155046 = {
+	name = "Tazir" #ibn Talha
+	dynasty = 1027014
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155043
+	1265.1.1 = {
+		birth = yes
+	}
+	1330.1.1 = {
+		death = yes
+	}
+}
+
+155047 = {
+	name = "Abd-al-'Aziz" #ibn Khurasan
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	1020.1.1 = {
+		birth = yes
+	}
+	1060.1.1 = {
+		death = yes
+	}
+}
+
+155048 = {
+	name = "Abd-al'Haqq" #ibn Abd-al-'Aziz
+	#Abu-Muhammad-Abd-al'Haqq
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155047
+	1040.1.1 = {
+		birth = yes
+	}
+	1095.1.1 = {
+		death = yes
+	}
+}
+
+155049 = {
+	name = "Abd-al-'Aziz" #ibn Abd-al'Haqq
+	#Abu-Muhammad-Abd-al-'Aziz
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155048
+	1060.1.1 = {
+		birth = yes
+	}
+	1105.9.17 = {
+		death = yes
+	}
+}
+
+155050 = {
+	name = "Ismail" #ibn Abd-al'Haqq
+	#Abu-al-Tahir-Ismail
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155048
+	1062.1.1 = {
+		birth = yes
+	}
+	1107.3.8 = {
+		death = yes
+	}
+}
+
+155051 = {
+	name = "Ahmad" #ibn Abu-Muhammad-Abd-al-'Aziz
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155049
+	1080.1.1 = {
+		birth = yes
+	}
+	1107.3.8 = {
+		trait = kinslayer
+		#assassinated his uncle, Ismail
+	}
+	1128.1.1 = {
+		death = yes
+	}
+}
+
+155052 = {
+	name = "Abu-Bakr" #ibn Abu-al-Tahir-Ismail
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155050
+	1080.1.1 = {
+		birth = yes
+	}
+	1148.8.1 = {
+		death = yes
+	}
+}
+
+155053 = {
+	name = "Abd-al-'Aziz" #ibn Abu-al-Tahir-Ismail
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155050
+	1082.1.1 = {
+		birth = yes
+	}
+	1108.1.1 = {
+		death = yes
+	}
+}
+
+155054 = {
+	name = "Abd-'Allah" #ibn Abd-al-'Aziz
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155053
+	1100.1.1 = {
+		birth = yes
+	}
+	1148.8.1 = {
+		trait = kinslayer
+		#drowned his uncle, Abu-Bakr
+	}
+	1159.2.1 = {
+		death = yes
+	}
+}
+
+155055 = {
+	name = "Ali" #ibn Ahmad
+	dynasty = 1027010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155051
+	1100.1.1 = {
+		birth = yes
+	}
+	1159.7.1 = {
+		death = yes
+	}
+}
+
+155056 = {
+	name = "Bahiyya" #bint Sharif-ad-Dawla al-Muizz
+	#placeholder
+	female = yes
+	dynasty = 595
+	religion = sunni
+	culture = maghreb_arabic
+	father = 20935
+	1041.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+155064 = {
+	name = "Ishaq" #ibn Muhammad ibn Tinaghmar
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155035
+	1075.1.1 = {
+		birth = yes
+	}
+	1120.1.1 = {
+		death = yes
+	}
+}
+
+155065 = {
+	name = "Yahya" #ibn Ishaq
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155064
+	1095.1.1 = {
+		birth = yes
+	}
+	1143.1.1 = {
+		death = yes
+	}
+}
+
+155066 = {
+	name = "Tifilwit"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155084
+	1020.1.1 = {
+		birth = yes
+	}
+	1060.1.1 = {
+		death = yes
+	}
+}
+
+155067 = {
+	name = "Ibrahim" #ibn Tifilwit
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155066
+	1040.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+155068 = {
+	name = "Abu-Bakr" #ibn Ibrahim
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155067
+	1066.1.1 = {
+		birth = yes
+	}
+	1117.7.1 = {
+		death = yes
+	}
+}
+
+155069 = {
+	name = "Ghaniya"
+	female = yes
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155036 #speculative
+	1080.1.1 = {
+		birth = yes
+	}
+	1125.1.1 = {
+		death = yes
+	}
+}
+
+155070 = {
+	name = "Yusuf"
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155084
+	1025.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+155071 = {
+	name = "Ali" #ibn Yusuf
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155070
+	1060.1.1 = {
+		birth = yes
+	}
+	1096.1.1 = {
+	add_spouse = 155069
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+155072 = {
+	name = "Yahya" #ibn Ghaniya
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155071
+	1100.1.1 = {
+		birth = yes
+	}
+	1150.1.1 = {
+		death = yes
+	}
+}
+
+155073 = {
+	name = "Muhammad"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155077
+	1000.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		death = yes
+	}
+}
+
+155074 = {
+	name = "al-Hajj"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155073
+	1040.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+155075 = {
+	name = "Muhammad" #ibn al-Hajj
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155074
+	1075.1.1 = {
+		birth = yes
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+155076 = {
+	name = "Abu-Bakr"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32962
+	1042.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		death = yes
+	}
+}
+
+155077 = {
+	name = "Turjut"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 273124
+	960.1.1 = {
+		birth = yes
+	}
+	1015.1.1 = {
+		death = yes
+	}
+}
+
+155078 = {
+	name = "Hamid"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155077
+	990.1.1 = {
+		birth = yes
+	}
+	1035.1.1 = {
+		death = yes
+	}
+}
+
+155079 = {
+	name = "Tilankan"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155078
+	1020.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		death = yes
+	}
+}
+
+155080 = {
+	name = "Mazdali"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155079
+	1050.1.1 = {
+		birth = yes
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+155081 = {
+	name = "Abd-'Allah"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155080
+	1070.1.1 = {
+		birth = yes
+	}
+	1145.1.1 = {
+		death = yes
+	}
+}
+
+155082 = {
+	name = "Abu-Bakr"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155080
+	1075.1.1 = {
+		birth = yes
+	}
+	1147.1.1 = {
+		death = yes
+	}
+}
+
+155083 = {
+	name = "Yahya"
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32968
+	1080.1.1 = {
+		birth = yes
+	}
+	1152.1.1 = {
+		death = yes
+	}
+}
+
+155084 = {
+	name = "Massufa"
+	#placeholder
+	dynasty = 1027007
+	religion = sunni
+	culture = maghreb_arabic
+	980.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+73609 = {
+	name = "Utman"
+	dynasty = 12257
+	religion = shiite
+	culture = maghreb_arabic
+	1163.1.1 = {
+		birth = yes
+	}
+	1213.1.1 = {
+		death = yes
+	}
+}
+
+73610 = {
+	name = "Abdallah"
+	dynasty = 12256
+	religion = shiite
+	culture = maghreb_arabic
+	father = 73611
+	1188.1.1 = {
+		birth = yes
+	}
+	1228.1.1 = {
+		death = yes
+	}
+}
+
+73611 = {
+	name = "Yahya"
+	dynasty = 12256
+	religion = shiite
+	culture = maghreb_arabic
+	1156.1.1 = {
+		birth = yes
+	}
+	1212.1.1 = {
+		death = yes
+	}
+}
+
+73612 = {
+	name = "Umar"
+	dynasty = 12256
+	religion = shiite
+	culture = maghreb_arabic
+	father = 73611
+	1181.1.1 = {
+		birth = yes
+	}
+	1234.1.1 = {
+		death = yes
+	}
+}
+
+73613 = {
+	name = "Abd-al-Rahman"
+	dynasty = 12258
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	1145.1.1 = {
+		birth = yes
+	}
+	1205.1.1 = {
+		death = yes
+	}
+}
+
+73614 = {
+	name = "Rashid"
+	dynasty = 12258
+	religion = shiite
+	culture = maghreb_arabic
+	father = 73613
+	1173.1.1 = {
+		birth = yes
+	}
+	1231.1.1 = {
+		death = yes
+	}
+}
+
+73615 = {
+	name = "Muhammad"
+	dynasty = 12259
+	religion = shiite
+	culture = maghreb_arabic
+	1155.1.1 = {
+		birth = yes
+	}
+	1208.1.1 = {
+		death = yes
+	}
+}
+
+73616 = {
+	name = "Yahya"
+	dynasty = 12259
+	religion = shiite
+	culture = maghreb_arabic
+	father = 73615
+	1178.1.1 = {
+		birth = yes
+	}
+	1228.1.1 = {
+		death = yes
+	}
+}
+
+73617 = {
+	name = "Tariq"
+	dynasty = 12258
+	religion = shiite
+	culture = maghreb_arabic
+	father = 73613
+	1177.1.1 = {
+		birth = yes
+	}
+	1232.1.1 = {
+		death = yes
+	}
+}
+
+73618 = {
+	name = "Umar"
+	dynasty = 12258
+	religion = shiite
+	culture = maghreb_arabic
+	father = 73613
+	1175.1.1 = {
+		birth = yes
+	}
+	1228.1.1 = {
+		death = yes
+	}
+}
+
+73619 = {
+	name = "Muhammad"
+	dynasty = 7276
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33012
+	1160.1.1 = {
+		birth = yes
+	}
+	1214.1.1 = {
+		death = yes
+	}
+}
+
+73620 = {
+	name = "Abd-al-Rahman"
+	dynasty = 7276
+
+	father = 73619
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	1198.1.1 = {
+		birth = yes
+	}
+	1227.1.1 = {
+		death = yes
+	}
+}
+
+73655 = {
+	name = "Betzenuriga"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73656
+	1300.1.1 = {
+		birth = yes
+	}
+	1358.1.1 = {
+		death = yes
+	}
+}
+
+73656 = {
+	name = "Vinque"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73657
+	1272.1.1 = {
+		birth = yes
+	}
+	1330.1.1 = {
+		death = yes
+	}
+}
+
+73657 = {
+	name = "Chindia"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73658
+	1257.1.1 = {
+		birth = yes
+	}
+	1305.1.1 = {
+		death = yes
+	}
+}
+
+73658 = {
+	name = "Binicherque"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73659
+	1220.1.1 = {
+		birth = yes
+	}
+	1273.1.1 = {
+		death = yes
+	}
+}
+
+73659 = {
+	name = "Archinife"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	mother = 73660
+	1196.1.1 = {
+		birth = yes
+	}
+	1234.1.1 = {
+		death = yes
+	}
+}
+
+73660 = {
+	name = "Yaiza"
+	dynasty = 100848
+	female = yes
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73661
+	1170.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+73661 = {
+	name = "Tamanca"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73662
+	1138.1.1 = {
+		birth = yes
+	}
+	1180.1.1 = {
+		death = yes
+	}
+}
+
+73662 = {
+	name = "Bencomo"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73663
+	1115.1.1 = {
+		birth = yes
+	}
+	1169.1.1 = {
+		death = yes
+	}
+}
+
+73663 = {
+	name = "Guanareme"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 73664
+	1088.1.1 = {
+		birth = yes
+	}
+	1144.1.1 = {
+		death = yes
+	}
+}
+
+73664 = {
+	name = "Betancaice"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 20842
+	1064.1.1 = {
+		birth = yes
+	}
+	1106.1.1 = {
+		death = yes
+	}
+}
+
+155085 = {
+	name = "Umar"
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32978
+	1138.1.1 = {
+		birth = yes
+	}
+	1191.1.1 = {
+		death = yes
+	}
+}
+
+155086 = {
+	name = "Uthman"
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32978
+	1138.1.1 = {
+		birth = yes
+	}
+	1196.1.1 = {
+		death = yes
+	}
+}
+
+155087 = {
+	name = "Abd-'Allah"
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32978
+	1120.1.1 = {
+		birth = yes
+	}
+	1190.1.1 = {
+		death = yes
+	}
+}
+
+155088 = {
+	name = "Ali"
+	dynasty = 101875
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32978
+	1112.1.1 = {
+		birth = yes
+	}
+	1163.1.1 = {
+		death = yes
+	}
+}
+
+155089 = {
+	name = "Umar" #ibn Al-Muizz
+	dynasty = 595
+	religion = sunni
+	culture = maghreb_arabic
+	father = 20935
+	1045.1.1 = {
+		birth = yes
+	}
+	1098.1.1 = {
+		death = yes
+	}
+}
+
+155090 = {
+	name = "Ballara" #ibn Tamim
+	female = yes
+	dynasty = 595
+	religion = sunni
+	culture = maghreb_arabic
+	father = 20825
+	1060.1.1 = {
+		birth = yes
+	}
+	1088.1.1 = {
+		death = yes
+	}
+}
+
+155091 = {
+	name = "Abu-Nas"
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155134
+	1130.1.1 = {
+		birth = yes
+	}
+	1180.1.1 = {
+		death = yes
+	}
+}
+
+155092 = {
+	name = "Abd-al-Rahman" #ibn Abu-Nas
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155091
+	1150.1.1 = {
+		birth = yes
+	}
+	1190.1.1 = {
+		death = yes
+	}
+}
+
+155093 = {
+	name = "Mandil" #ibn Abd-al-Rahman
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155092
+	1170.1.1 = {
+		birth = yes
+	}
+	1226.1.1 = {
+		death = yes
+	}
+}
+
+155094 = {
+	name = "Al-'Abbas" #ibn Mandil
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155093
+	1188.1.1 = {
+		birth = yes
+	}
+	1249.1.1 = {
+		death = yes
+	}
+}
+
+155095 = {
+	name = "Muhammad" #ibn Mandil
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155093
+	1200.1.1 = {
+		birth = yes
+	}
+	1263.1.1 = {
+		death = yes
+	}
+}
+
+155096 = {
+	name = "Ayd" #ibn Mandil
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155093
+	1204.1.1 = {
+		birth = yes
+	}
+	1263.1.1 = {
+		trait = kinslayer
+	}
+	1269.1.1 = {
+		death = yes
+	}
+}
+
+155097 = {
+	name = "Umar" #ibn Mandil
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155093
+	1213.1.1 = {
+		birth = yes
+	}
+	1278.1.1 = {
+		death = yes
+	}
+}
+
+155098 = {
+	name = "Thabit" #ibn Mandil
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155093
+	1222.1.1 = {
+		birth = yes
+	}
+	1294.1.1 = {
+		death = yes
+	}
+}
+
+155099 = {
+	name = "Muhammad" #ibn Thabit
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155098
+	1245.1.1 = {
+		birth = yes
+	}
+	1295.1.1 = {
+		death = yes
+	}
+}
+
+155100 = {
+	name = "Rashid" #ibn Thabit
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155098
+	1255.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+155101 = {
+	name = "Waghram" #ibn Mandil
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155093
+	1223.1.1 = {
+		birth = yes
+	}
+	1280.1.1 = {
+		death = yes
+	}
+}
+
+155102 = {
+	name = "Umar" #ibn Maghram
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155101
+	1250.1.1 = {
+		birth = yes
+	}
+	1302.1.1 = {
+		death = yes
+	}
+}
+
+155103 = {
+	name = "Ali" #ibn Rashid
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155100
+	1285.1.1 = {
+		birth = yes
+	}
+	1352.1.1 = {
+		death = yes
+	}
+}
+
+155104 = {
+	name = "Khalaf"
+	#placeholder
+	dynasty = 1027012
+	religion = sunni
+	culture = maghreb_arabic
+	1134.1.1 = {
+		birth = yes
+	}
+	1182.1.1 = {
+		death = yes
+	}
+}
+
+155105 = {
+	name = "Duwud"
+	#placeholder
+	dynasty = 1027012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155104
+	1162.1.1 = {
+		birth = yes
+	}
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+155106 = {
+	name = "Sufyan"
+	#placeholder
+	dynasty = 1027012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155171
+	1255.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+155107 = {
+	name = "Imran"
+	#placeholder
+	dynasty = 1027012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155106
+	1285.1.1 = {
+		birth = yes
+	}
+	1339.1.1 = {
+		death = yes
+	}
+}
+
+155108 = {
+	name = "Muhammad"
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	1140.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+155109 = {
+	name = "Yusuf" #ibn Muhammad
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155108
+	1160.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+155110 = {
+	name = "Djabar" #ibn Yusuf
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155109
+	1180.1.1 = {
+		birth = yes
+	}
+	1232.1.1 = {
+		death = yes
+	}
+}
+
+155111 = {
+	name = "Uthman" #ibn Yusuf
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155109
+	1185.1.1 = {
+		birth = yes
+	}
+	1234.1.1 = {
+		death = yes
+	}
+}
+
+155112 = {
+	name = "Zaydan" #ibn Zayyan
+	dynasty = 7277
+	religion = sunni
+	culture = maghreb_arabic
+	father = 33044
+	1200.1.1 = {
+		birth = yes
+	}
+	1236.1.1 = {
+		death = yes
+	}
+}
+
+155115 = {
+	name = "Muhammad" #ibn Abd-al-Karim
+	dynasty = 1027015
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155235
+	1160.1.1 = {
+		birth = yes
+	}
+	1207.1.1 = {
+		death = yes
+	}
+}
+
+155116 = {
+	name = "Khazer"
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	845.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+155117 = {
+	name = "Felful" #ibn Khazer
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155116
+	870.1.1 = {
+		birth = yes
+	}
+	925.1.1 = {
+		death = yes
+	}
+}
+
+155118 = {
+	name = "Khazrun" #ibn Felful
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155117
+	895.1.1 = {
+		birth = yes
+	}
+	950.1.1 = {
+		death = yes
+	}
+}
+
+155119 = {
+	name = "Abd-'Allah" #ibn Khazrun
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155118
+	914.1.1 = {
+		birth = yes
+	}
+	965.1.1 = {
+		death = yes
+	}
+}
+
+155120 = {
+	name = "Attia" #ibn Abdallah
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155119
+	933.1.1 = {
+		birth = yes
+	}
+	980.1.1 = {
+		death = yes
+	}
+}
+
+155121 = {
+	name = "Ziri" #ibn Attia
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155120
+	952.1.1 = {
+		birth = yes
+	}
+	1002.1.1 = {
+		death = yes
+	}
+}
+
+155122 = {
+	name = "Said" #ibn Khazrun
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155118
+	920.1.1 = {
+		birth = yes
+	}
+	975.1.1 = {
+		death = yes
+	}
+}
+
+155123 = {
+	name = "Felful" #ibn Said
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155122
+	950.1.1 = {
+		birth = yes
+	}
+	1009.1.1 = {
+		death = yes
+	}
+}
+
+155124 = {
+	name = "Warru" #ibn Said
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155122
+	955.1.1 = {
+		birth = yes
+	}
+	1012.1.1 = {
+		death = yes
+	}
+}
+
+155125 = {
+	name = "Khazrun" #ibn Said
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155122
+	960.1.1 = {
+		birth = yes
+	}
+	1022.1.1 = {
+		death = yes
+	}
+}
+
+155126 = {
+	name = "Khalifa" #ibn Warru
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155124
+	975.1.1 = {
+		birth = yes
+	}
+	1028.1.1 = {
+		death = yes
+	}
+}
+
+155127 = {
+	name = "Said" #ibn Khazrun-ibn-Said
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155125
+	980.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		death = yes
+	}
+}
+
+155128 = {
+	name = "Khazrun" #ibn Khalifa-ibn-Warru
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155126
+	995.1.1 = {
+		birth = yes
+	}
+	1053.1.1 = {
+		death = yes
+	}
+}
+
+155129 = {
+	name = "Abd-'Allah" #ibn Khazrun
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155128
+	1015.1.1 = {
+		birth = yes
+	}
+	1058.1.1 = {
+		death = yes
+	}
+}
+
+155130 = {
+	name = "al-Muntasir" #ibn Khazrun
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155128
+	1020.1.1 = {
+		birth = yes
+	}
+	1068.1.1 = {
+		death = yes
+	}
+}
+
+155131 = {
+	name = "Khalifa" #ibn Khazrun
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155128
+	1025.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+155132 = {
+	name = "Yahya"
+	#placeholder
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155129
+	1040.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+155133 = {
+	name = "Khazrun"
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155132
+	1070.1.1 = {
+		birth = yes
+	}
+	1115.1.1 = {
+		death = yes
+	}
+}
+
+155134 = {
+	name = "Muhammad" #ibn Khazrun
+	dynasty = 1027001
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155133
+	1095.1.1 = {
+		birth = yes
+	}
+	1146.1.1 = {
+		death = yes
+	}
+}
+
+155135 = {
+	name = "Matruh"
+	dynasty = 1027016
+	religion = sunni
+	culture = maghreb_arabic
+	1100.1.1 = {
+		birth = yes
+	}
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+155136 = {
+	name = "Abu-Yahya" #ibn Matruh
+	dynasty = 1027016
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155135
+	1120.1.1 = {
+		birth = yes
+	}
+	1172.1.1 = {
+		death = yes
+	}
+}
+
+155163 = {
+	name = "Abd-'Allah" #ibn Abd-al-Haqq
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 32993
+	1205.1.1 = {
+		birth = yes
+	}
+	1250.1.1 = {
+		death = yes
+	}
+}
+
+155164 = {
+	name = "Yakub" #ibn Abd-'Allah
+	dynasty = 101732
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155163
+	1225.1.1 = {
+		birth = yes
+	}
+	1275.1.1 = {
+		death = yes
+	}
+}
+
+155165 = {
+	name = "Mansur"
+	#placeholder
+	dynasty = 1027020
+	religion = sunni
+	culture = maghreb_arabic
+	1220.1.1 = {
+		birth = yes
+	}
+	1267.1.1 = {
+		death = yes
+	}
+}
+
+155166 = {
+	name = "Amr"
+	#placeholder
+	dynasty = 1027019
+	religion = sunni
+	culture = maghreb_arabic
+	1215.1.1 = {
+		birth = yes
+	}
+	1267.1.1 = {
+		death = yes
+	}
+}
+
+155167 = {
+	name = "Abd-al-Qasim"
+	dynasty = 1027019
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155166
+	1240.1.1 = {
+		birth = yes
+	}
+	1287.1.1 = {
+		death = yes
+	}
+}
+
+155168 = {
+	name = "Umar"
+	#placeholder
+	dynasty = 1027019
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155167
+	1265.1.1 = {
+		birth = yes
+	}
+	1316.1.1 = {
+		death = yes
+	}
+}
+
+155169 = {
+	name = "Yahya"
+	dynasty = 1027019
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155168
+	1290.1.1 = {
+		birth = yes
+	}
+	1340.1.1 = {
+		death = yes
+	}
+}
+
+155170 = {
+	name = "Abd-al-Qawi"
+	dynasty = 1027012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155105
+	1190.1.1 = {
+		birth = yes
+	}
+	1253.1.1 = {
+		death = yes
+	}
+}
+
+155171 = {
+	name = "Muhammad" #ibn Abd-al-Qawi
+	dynasty = 1027012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155170
+	1225.1.1 = {
+		birth = yes
+	}
+	1281.1.1 = {
+		death = yes
+	}
+}
+
+155235 = {
+	name = "Abd-al-Karim"
+	dynasty = 1027015
+	religion = sunni
+	culture = maghreb_arabic
+	1144.1.1 = {
+		birth = yes
+	}
+	1190.1.11 = {
+		death = yes
+	}
+}
+
+155236 = {
+	name = "Muhammad"
+	dynasty = 1027021
+	religion = sunni
+	culture = maghreb_arabic
+	1255.1.1 = {
+		birth = yes
+	}
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+155237 = {
+	name = "Thabit"
+	dynasty = 1027021
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155236
+	1280.1.1 = {
+		birth = yes
+	}
+	1327.1.1 = {
+		death = yes
+	}
+}
+
+155238 = {
+	name = "Muhammad"
+	dynasty = 1027021
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155237
+	1305.1.1 = {
+		birth = yes
+	}
+	1348.1.1 = {
+		death = yes
+	}
+}
+
+155239 = {
+	name = "Thabit"
+	dynasty = 1027021
+	religion = sunni
+	culture = maghreb_arabic
+	father = 155238
+	1330.1.1 = {
+		birth = yes
+	}
+	1355.1.1 = {
+		death = yes
+	}
+}
+
+73687 = {
+	name = "Ali"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73688
+	958.1.1 = {
+		birth = yes
+	}
+	1018.3.22 = {
+		death = yes
+	}
+}
+
+73688 = {
+	name = "Yahya"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159493
+	930.1.1 = {
+		birth = yes
+	}
+	980.1.1 = {
+		death = yes
+	}
+}
+
+73689 = {
+	name = "al-Qasim"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73688
+	961.1.1 = {
+		birth = yes
+	}
+	1023.2.2 = {
+		death = yes
+	}
+}
+
+73690 = {
+	name = "Yahya"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73687
+	980.1.1 = {
+		birth = yes
+	}
+	1035.1.1 = {
+		death = yes
+	}
+}
+
+159183 = {
+	name = "Hassan"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159195
+	880.1.1 = {
+		birth = yes
+	}
+	964.1.1 = {
+		death = yes
+	}
+}
+
+159184 = {
+	name = "Ahmad"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159183
+	910.1.1 = {
+		birth = yes
+	}
+	970.1.1 = {
+		death = yes
+	}
+}
+
+159185 = {
+	name = "Ali Abu'l Qasim"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159183
+	911.1.1 = {
+		birth = yes
+	}
+	982.1.1 = {
+		death = yes
+	}
+}
+
+159186 = {
+	name = "Jabir"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159183
+	930.1.1 = {
+		birth = yes
+	}
+	983.1.1 = {
+		death = yes
+	}
+}
+
+159187 = {
+	name = "Muhammad"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159183
+	931.1.1 = {
+		birth = yes
+	}
+	980.1.1 = {
+		death = yes
+	}
+}
+
+159188 = {
+	name = "Jafar"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159187
+	950.1.1 = {
+		birth = yes
+	}
+	986.1.1 = {
+		death = yes
+	}
+}
+
+159189 = {
+	name = "Abdallah"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159187
+	951.1.1 = {
+		birth = yes
+	}
+	986.6.1 = {
+		death = yes
+	}
+}
+
+159190 = {
+	name = "Yusuf"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159187
+	952.1.1 = {
+		birth = yes
+	}
+	998.1.1 = {
+		death = yes
+	}
+}
+
+159191 = {
+	name = "Jafar"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159190
+	953.1.1 = {
+		birth = yes
+	}
+	1019.1.1 = {
+		death = yes
+	}
+}
+
+159192 = {
+	name = "Ahmad"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159190
+	960.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		death = yes
+	}
+}
+
+159193 = {
+	name = "Hassan"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159192
+	1000.1.1 = {
+		birth = yes
+	}
+	1053.1.1 = {
+		death = yes
+	}
+}
+
+159194 = {
+	name = "Ibrahim"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	father = 159192
+	1001.1.1 = {
+		birth = yes
+	}
+	1050.1.1 = {
+		death = yes
+	}
+}
+
+159195 = {
+	name = "Ali"
+	dynasty = 12240
+	religion = shiite
+	culture = maghreb_arabic
+	850.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+159490 = {
+	name = "Muhammad" #
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73689
+	990.1.1 = {
+		birth = yes #Unknown
+	}
+	1048.1.1 = {
+		death = yes
+	}
+}
+
+159491 = {
+	name = "al-Wathiq" #
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73689
+	1007.1.1 = {
+		birth = yes #Unknown
+	}
+	1042.1.1 = {
+		death = yes
+	}
+}
+
+159492 = {
+	name = "al-Qasim" #
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159491
+	1042.1.1 = {
+		birth = yes #Unknown
+		add_claim = c_algeciras
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+159493 = {
+	name = "Hammud" #
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159512
+	900.1.1 = {
+		birth = yes #Unknown
+	}
+	950.1.1 = {
+		death = yes
+	}
+}
+
+159494 = {
+	name = "Idris"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73688
+	960.1.1 = {
+		birth = yes
+	}
+	1039.5.2 = {
+		death = yes
+	}
+}
+
+159495 = {
+	name = "Hasan"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73687
+	970.1.1 = {
+		birth = yes
+	}
+	1042.5.12 = {
+		death = yes
+	}
+}
+
+159496 = {
+	name = "Yahya"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159494
+	990.1.1 = {
+		birth = yes
+	}
+	1040.5.2 = {
+		death = yes
+	}
+}
+
+159497 = {
+	name = "Idris"
+	dynasty = 7501
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 73687
+	970.1.1 = {
+		birth = yes
+	}
+	1054.5.12 = {
+		death = yes
+	}
+}
+
+159498 = {
+	name = "Idris"
+	dynasty = 7501
+
+	father = 73690
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	trait = sayyid
+
+	1005.1.1 = {
+		birth = yes
+	}
+	1060.5.12 = {
+		death = yes
+	}
+}
+
+159499 = {
+	name = "Muhammad"
+	dynasty = 7501
+
+	father = 159497
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	trait = sayyid
+
+	1010.1.1 = {
+		birth = yes
+	}
+	1070.5.12 = {
+		death = yes
+	}
+}
+
+159500 = {
+	name = "Yahya"
+	dynasty = 7501
+
+	father = 159498
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	trait = sayyid
+
+	1035.1.1 = {
+		birth = yes
+	}
+	1065.12.16 = {
+		death = yes
+	}
+}
+
+159502 = {
+	name = "Idris"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159501
+	791.1.2 = {
+		birth = yes
+	}
+	828.12.16 = {
+		death = yes
+	}
+}
+
+159503 = {
+	name = "Muhammad"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159502
+	810.1.2 = {
+		birth = yes
+	}
+	836.12.16 = {
+		death = yes
+	}
+}
+
+159504 = {
+	name = "Ali"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159503
+	827.1.2 = {
+		birth = yes
+	}
+	848.12.16 = {
+		death = yes
+	}
+}
+
+159505 = {
+	name = "Yahya"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159503
+	829.1.2 = {
+		birth = yes
+	}
+	864.12.16 = {
+		death = yes
+	}
+}
+
+159506 = {
+	name = "Yahya"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159505
+	845.1.2 = {
+		birth = yes
+	}
+	874.12.16 = {
+		death = yes
+	}
+}
+
+159507 = {
+	name = "Umar"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159505
+	846.1.2 = {
+		birth = yes
+	}
+	863.12.16 = {
+		death = yes
+	}
+}
+
+159508 = {
+	name = "Ali"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159507
+	860.1.2 = {
+		birth = yes
+	}
+	883.12.16 = {
+		death = yes
+	}
+}
+
+159509 = {
+	name = "Al-Qasim"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159506
+	860.1.2 = {
+		birth = yes
+	}
+	880.12.16 = {
+		death = yes
+	}
+}
+
+159510 = {
+	name = "Yahya"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159509
+	875.1.2 = {
+		birth = yes
+	}
+	904.12.16 = {
+		death = yes
+	}
+}
+
+159511 = {
+	name = "Idris"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159507
+	862.1.1 = {
+		birth = yes
+	}
+	900.12.16 = {
+		death = yes
+	}
+}
+
+159512 = {
+	name = "Yahya"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159511
+	880.1.2 = {
+		birth = yes
+	}
+	917.12.16 = {
+		death = yes
+	}
+}
+
+159513 = {
+	name = "Muhammad"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159509
+	885.1.2 = {
+		birth = yes
+	}
+	927.12.16 = {
+		death = yes
+	}
+}
+
+159514 = {
+	name = "Al-Hassan"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159513
+	900.1.2 = {
+		birth = yes
+	}
+	944.12.16 = {
+		death = yes
+	}
+}
+
+159515 = {
+	name = "Ibrahim"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159513
+	900.1.2 = {
+		birth = yes
+	}
+	942.12.16 = {
+		death = yes
+	}
+}
+
+159516 = {
+	name = "Al-Qasim Kannun"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159515
+	920.1.2 = {
+		birth = yes
+	}
+	948.12.16 = {
+		death = yes
+	}
+}
+
+159517 = {
+	name = "Ahmad"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159516
+	935.1.2 = {
+		birth = yes
+	}
+	954.12.16 = {
+		death = yes
+	}
+}
+
+159518 = {
+	name = "Al-Hasan"
+	dynasty = 1029055
+	religion = shiite
+	culture = maghreb_arabic
+	trait = sayyid
+	father = 159516
+	935.1.2 = {
+		birth = yes
+	}
+	985.12.16 = {
+		death = yes
+	}
+}
+
+163094 = {
+	name = "Sawdan"
+	dynasty = 806
+	religion = sunni
+	culture = maghreb_arabic
+	830.1.1 = {
+		birth = yes
+	}
+	871.1.1 = {
+		death = yes
+	}
+}
+
+163097 = {
+	name = "Aflah"
+	dynasty = 808
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 210030 #added father
+	800.1.1 = {
+		birth = yes
+	}
+	872.1.1 = {
+		death = yes
+	}
+}
+
+166423 = {
+	name = "Guanareme"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	831.1.1 = {
+		birth = yes
+	}
+	877.1.1 = {
+		death = yes
+	}
+}
+
+166424 = {
+	name = "Añaterve"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166423
+	850.1.1 = {
+		birth = yes
+	}
+	906.1.1 = {
+		death = yes
+	}
+}
+
+166425 = {
+	name = "Zonzamas"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166424
+	867.1.1 = {
+		birth = yes
+	}
+	929.1.1 = {
+		death = yes
+	}
+}
+
+166426 = {
+	name = "Titañe"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166425
+	890.1.1 = {
+		birth = yes
+	}
+	941.1.1 = {
+		death = yes
+	}
+}
+
+166427 = {
+	name = "Ayoze"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166426
+	911.1.1 = {
+		birth = yes
+	}
+	964.1.1 = {
+		death = yes
+	}
+}
+
+166428 = {
+	name = "Dardamo"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166427
+	936.1.1 = {
+		birth = yes
+	}
+	979.1.1 = {
+		death = yes
+	}
+}
+
+166429 = {
+	name = "Betzenuhya"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166428
+	955.1.1 = {
+		birth = yes
+	}
+	994.1.1 = {
+		death = yes
+	}
+}
+
+166430 = {
+	name = "Guardafía"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166429
+	977.1.1 = {
+		birth = yes
+	}
+	1010.1.1 = {
+		death = yes
+	}
+}
+
+166431 = {
+	name = "Imobach"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166430
+	994.1.1 = {
+		birth = yes
+	}
+	1036.1.1 = {
+		death = yes
+	}
+}
+
+166432 = {
+	name = "Adxoña"
+	dynasty = 100848
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 166431
+	1017.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		death = yes
+	}
+}
+
+73949 = {
+	name = "Musarra"
+	dynasty = 12303
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	816.1.1 = {
+		birth = yes
+	}
+	867.1.1 = {
+		death = yes
+	}
+}
+
+73950 = {
+	name = "Ibrahim"
+	dynasty = 12303
+
+	father = 73949
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	839.1.1 = {
+		birth = yes
+	}
+	893.1.1 = {
+		death = yes
+	}
+}
+
+73951 = {
+	name = "Abdallah"
+	dynasty = 12303
+
+	father = 73949
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	842.1.1 = {
+		birth = yes
+	}
+	899.1.1 = {
+		death = yes
+	}
+}
+
+163148 = {
+	name = "Abu Bakr"
+	dynasty = 808
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 163097
+	830.1.1 = {
+		birth = yes
+	}
+	873.1.1 = {
+		death = yes
+	}
+}
+
+163149 = {
+	name = "Muhammad"
+	dynasty = 808
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 163097
+	832.1.1 = {
+		birth = yes
+	}
+	894.1.1 = {
+		death = yes
+	}
+}
+
+163150 = {
+	name = "Yaqub"
+	dynasty = 808
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 163097
+	834.1.1 = {
+		birth = yes
+	}
+	901.1.1 = {
+		death = yes
+	}
+}
+
+168253 = {
+	name = "Mansur"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	660.1.1 = {
+		birth = yes
+	}
+	710.1.1 = {
+		death = yes
+	}
+}
+
+168254 = {
+	name = "Salih"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168253
+	690.1.1 = {
+		birth = yes
+	}
+	749.1.1 = {
+		death = yes
+	}
+}
+
+168255 = {
+	name = "al-Mu'tasim"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168254
+	710.1.1 = {
+		birth = yes
+	}
+	755.1.1 = {
+		death = yes
+	}
+}
+
+168256 = {
+	name = "Idris"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168255
+	728.1.1 = {
+		birth = yes
+	}
+	760.1.1 = {
+		death = yes
+	}
+}
+
+168257 = {
+	name = "Sa'id"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168256
+	745.1.1 = {
+		birth = yes
+	}
+	803.1.1 = {
+		death = yes
+	}
+}
+
+168258 = {
+	name = "Salih"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168257
+	790.1.1 = {
+		birth = yes
+	}
+	864.1.1 = {
+		death = yes
+	}
+}
+
+168259 = {
+	name = "Sa'id"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168258
+	830.1.1 = {
+		birth = yes
+	}
+	916.1.1 = {
+		death = yes
+	}
+}
+
+168260 = {
+	name = "Salih"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168259
+	855.1.1 = {
+		birth = yes
+	}
+	927.1.1 = {
+		death = yes
+	}
+}
+
+168261 = {
+	name = "Abd-al-Badi"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168260
+	875.1.1 = {
+		birth = yes
+	}
+	929.1.1 = {
+		death = yes
+	}
+}
+
+168262 = {
+	name = "Abd-ar-Rahman"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168259
+	860.1.1 = {
+		birth = yes
+	}
+	910.1.1 = {
+		death = yes
+	}
+}
+
+168263 = {
+	name = "Abd-al-Malik"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168262
+	880.1.1 = {
+		birth = yes
+	}
+	925.1.1 = {
+		death = yes
+	}
+}
+
+168264 = {
+	name = "Isma'il"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168263
+	900.1.1 = {
+		birth = yes
+	}
+	935.1.1 = {
+		death = yes
+	}
+}
+
+168265 = {
+	name = "Idris"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168257
+	795.1.1 = {
+		birth = yes
+	}
+	850.1.1 = {
+		death = yes
+	}
+}
+
+168266 = {
+	name = "Abd-as-Sami"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168265
+	830.1.1 = {
+		birth = yes
+	}
+	880.1.1 = {
+		death = yes
+	}
+}
+
+168267 = {
+	name = "Rumi"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168266
+	850.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+168268 = {
+	name = "Musa"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168267
+	880.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+168269 = {
+	name = "Idris"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168258
+	835.1.1 = {
+		birth = yes
+	}
+	885.1.1 = {
+		death = yes
+	}
+}
+
+168270 = {
+	name = "Jurthum"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168269
+	855.1.1 = {
+		birth = yes
+	}
+	905.1.1 = {
+		death = yes
+	}
+}
+
+168271 = {
+	name = "Adb-as-Sami"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168270
+	885.1.1 = {
+		birth = yes
+	}
+	947.1.1 = {
+		death = yes
+	}
+}
+168272 = {
+	name = "Sa'id"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168269
+	860.1.1 = {
+		birth = yes
+	}
+	910.1.1 = {
+		death = yes
+	}
+}
+
+168273 = {
+	name = "Ziyadet"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168272
+	880.1.1 = {
+		birth = yes
+	}
+	930.1.1 = {
+		death = yes
+	}
+}
+
+168274 = {
+	name = "Jurthum"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168282
+	920.1.1 = {
+		birth = yes
+	}
+	970.1.1 = {
+		death = yes
+	}
+}
+
+168275 = {
+	name = "Tarif"
+	dynasty = 9576
+	religion = sunni
+	culture = maghreb_arabic
+	690.1.1 = {
+		birth = yes
+	}
+	744.1.1 = {
+		death = yes
+	}
+}
+
+168276 = {
+	name = "Salih"
+	dynasty = 9576
+	religion = shiite #changed religion
+	culture = maghreb_arabic
+	father = 168275
+	720.1.1 = {
+		birth = yes
+	}
+	792.1.1 = {
+		death = yes
+	}
+}
+
+168277 = {
+	name = "Ilyas"
+	dynasty = 9576
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168276
+	775.1.1 = {
+		birth = yes
+	}
+	842.1.1 = {
+		death = yes
+	}
+}
+
+168278 = {
+	name = "Yunus"
+	dynasty = 9576
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168277
+	820.1.1 = {
+		birth = yes
+	}
+	888.1.1 = {
+		death = yes
+	}
+}
+
+168279 = {
+	name = "Muhammad"
+	dynasty = 9576
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168278
+	855.1.1 = {
+		birth = yes
+	}
+	917.1.1 = {
+		death = yes
+	}
+}
+
+168280 = {
+	name = "Abdullah"
+	dynasty = 9576
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168279
+	895.1.1 = {
+		birth = yes
+	}
+	961.1.1 = {
+		death = yes
+	}
+}
+
+168281 = {
+	name = "Mansur"
+	dynasty = 9576
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168280
+	939.1.1 = {
+		birth = yes
+	}
+	989.1.1 = {
+		death = yes
+	}
+}
+
+168282 = {
+	name = "Ahmad"
+	dynasty = 9575
+	religion = sunni
+	culture = maghreb_arabic
+	father = 168273
+	900.1.1 = {
+		birth = yes
+	}
+	945.1.1 = {
+		death = yes
+	}
+}
+
+73183 = {
+	name = "Tifilwit"
+	dynasty = 12193
+
+	religion = sunni
+	culture = maghreb_arabic
+	1066.1.1 = {
+		birth = yes
+	}
+	1118.12.18 = {
+		death = yes
+	}
+}
+
+73838 = {
+	name = "Izraq"
+	dynasty = 12294
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	830.1.1 = {
+		birth = yes
+	}
+	860.1.1 = {
+		add_spouse = 73837
+	}
+	888.1.1 = {
+		death = yes
+	}
+}
+
+200230 = {
+	name = "Abd-al-Malik"
+	dynasty = 1046028
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	729.1.1 = {
+		birth = yes
+	}
+	760.1.1 = {
+		add_spouse = 200231
+	}
+	781.1.1 = {
+		death = yes
+	}
+}
+
+200232 = {
+	name = "Ya'qub"
+	dynasty = 1046028
+
+	father = 200230
+	mother = 200231
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	762.1.1 = {
+		birth = yes
+	}
+	816.1.1 = {
+		death = yes
+	}
+}
+
+200233 = {
+	name = "Idris"
+	dynasty = 7501
+
+	father = 159496
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	1020.1.1 = {
+		birth = yes
+	}
+	1067.1.1 = {
+		death = yes
+	}
+}
+
+200234 = {
+	name = "Muhammad"
+	dynasty = 7501
+
+	father = 159498
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	1030.1.1 = {
+		birth = yes
+	}
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+200235 = {
+	name = "Rahima"
+	female = yes
+	dynasty = 7501
+
+	father = 159498
+
+	religion = shiite
+	culture = maghreb_arabic
+
+	1037.1.1 = {
+		birth = yes
+	}
+	1095.1.1 = {
+		death = yes
+	}
+}
+
+200214 = {
+	name = "Abd-al-Karim"
+	dynasty = 1046020
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	730.1.1 = {
+		birth = yes
+	}
+	763.1.1 = {
+		add_spouse = 200215
+	}
+	784.1.1 = {
+		death = yes
+	}
+}
+
+200216 = {
+	name = "Yahya"
+	dynasty = 1046021
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	748.1.1 = {
+		birth = yes
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+200217 = {
+	name = "Muhammad"
+	dynasty = 1046022
+
+	religion = sunni
+	culture = maghreb_arabic
+
+	730.1.1 = {
+		birth = yes
+	}
+	760.1.1 = {
+		add_spouse = 200218
+	}
+	783.1.1 = {
+		death = yes
+	}
+}
+
+210028 = {
+	name = "Rustam"
+	dynasty = 808
+	religion = ibadi
+	culture = maghreb_arabic
+	708.1.1 = {
+		birth = yes
+	}
+	755.1.1 = {
+		death = yes
+	}
+}
+
+210029 = {
+	name = "Abdul-Rahman"
+	dynasty = 808
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 210028
+	728.1.1 = {
+		birth = yes
+	}
+	784.1.1 = {
+		death = yes
+	}
+}
+
+210030 = {
+	name = "Wahab"
+	dynasty = 808
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 210029
+	750.1.1 = {
+		birth = yes
+	}
+	823.1.1 = {
+		death = yes
+	}
+}
+
+210031 = {
+	name = "Hatim" #ibadi rebel
+	dynasty = 1048003
+	religion = ibadi
+	culture = maghreb_arabic
+	720.1.1 = {
+		birth = yes
+	}
+	772.1.1 = {
+		death = yes
+	}
+}
+
+210032 = {
+	name = "Abu Qurra" #first Ifrinid leader
+	dynasty = 1048004
+	religion = ibadi
+	culture = maghreb_arabic
+	720.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+210033 = {
+	name = "Al-Qasim" # Midrarid leader
+	dynasty = 1048005
+	religion = ibadi
+	culture = maghreb_arabic
+	725.1.1 = {
+		birth = yes
+	}
+	798.1.1 = {
+		death = yes
+	}
+}
+
+210034 = {
+	name = "Azim" # fictitious ruler of Cyrenaica
+	dynasty = 1048006
+	religion = sunni
+	culture = maghreb_arabic
+	730.1.1 = {
+		birth = yes
+	}
+	788.1.1 = {
+		death = yes
+	}
+}
+
+210035 = {
+	name = "Hashim" # fictitious ruler of Kabylia
+	dynasty = 1048007
+	religion = sunni
+	culture = maghreb_arabic
+	735.1.1 = {
+		birth = yes
+	}
+	793.1.1 = {
+		death = yes
+	}
+}
+
+210036 = {
+	name = "Kamal" # fictitious
+	dynasty = 1048008
+	religion = ibadi
+	culture = maghreb_arabic
+	728.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+210037 = {
+	name = "Abdul-Rahman" # fictitious
+	dynasty = 1048009
+	religion = ibadi
+	culture = maghreb_arabic
+	732.1.1 = {
+		birth = yes
+	}
+	788.1.1 = {
+		death = yes
+	}
+}
+
+210038 = {
+	name = "Hamad" # fictitious
+	dynasty = 1048010
+	religion = ibadi
+	culture = maghreb_arabic
+	735.1.1 = {
+		birth = yes
+	}
+	798.1.1 = {
+		death = yes
+	}
+}
+
+210039 = {
+	name = "Masmud" # fictitious
+	dynasty = 1048011
+	religion = shiite
+	culture = maghreb_arabic
+	733.1.1 = {
+		birth = yes
+	}
+	793.1.1 = {
+		death = yes
+	}
+}
+
+210040 = {
+	name = "Mahtar" # fictitious
+	dynasty = 1048012
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	740.1.1 = {
+		birth = yes
+	}
+	802.1.1 = {
+		death = yes
+	}
+}
+
+188756 = {
+	name = "Ugdada" # fictitious holder of Ouadane
+	dynasty = 1042177
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	742.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+188757 = {
+	name = "Awzal" # fictitious holder of Idjil
+	dynasty = 1042178
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	733.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+188758 = {
+	name = "Akateiaji" # fictitious holder of Taghaza
+	dynasty = 1042179
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	718.1.1 = {
+		birth = yes
+	}
+	775.1.1 = {
+		death = yes
+	}
+}
+
+188759 = {
+	name = "Gulusa" # fictitious holder of Araouane
+	dynasty = 1042180
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	750.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+188760 = {
+	name = "Lacumaces" # fictitious
+	dynasty = 1042179
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 188758
+	748.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+#Fictional Tora rulers
+248699 = {
+	name = "Born"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	740.1.1 = {
+		birth = yes # maybe
+	}
+	805.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248700 = {
+	name = "Ede"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248699
+	769.1.1 = {
+		birth = yes # maybe
+	}
+	839.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248701 = {
+	name = "Gakuwe"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248700
+	810.1.1 = {
+		birth = yes # maybe
+	}
+	880.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248702 = {
+	name = "Chaski"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248701
+	864.1.1 = {
+		birth = yes # maybe
+	}
+	920.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248703 = {
+	name = "Bis"
+	female = yes
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248701
+	867.1.1 = {
+		birth = yes # maybe
+	}
+	922.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248704 = {
+	name = "Bug"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248702
+	900.1.1 = {
+		birth = yes # maybe
+	}
+	960.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248705 = {
+	name = "Dahab"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248704
+	935.1.1 = {
+		birth = yes # maybe
+	}
+	1000.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248706 = {
+	name = "Gon"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248705
+	965.1.1 = {
+		birth = yes # maybe
+	}
+	1030.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248707 = {
+	name = "Izza"
+	dynasty = 1059972
+	religion = west_african_pagan
+	culture = maghreb_arabic
+	father = 248706
+	1010.1.1 = {
+		birth = yes # maybe
+	}
+	1060.1.1 = {
+		death = yes # maybe
+	}
+}
+
+#End of fictional Tora rulers
+
+161076 = {
+	name = "Kabayo"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	1050.1.1 = {
+		birth = yes
+	}
+
+	1110.1.1 = {
+		death = yes
+	}
+}
+
+161077 = {
+	name = "Cisse"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161076
+	1080.1.1 = {
+		birth = yes
+	}
+
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+161078 = {
+	name = "Demba"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161077
+	1110.1.1 = {
+		birth = yes
+	}
+
+	1170.1.1 = {
+		death = yes
+	}
+}
+
+161079 = {
+	name = "Daoud"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161078
+	1150.1.1 = {
+		birth = yes
+	}
+
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+161080 = {
+	name = "Ishaq"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161079
+	1180.1.1 = {
+		birth = yes
+	}
+
+	1240.1.1 = {
+		death = yes
+	}
+}
+
+161081 = {
+	name = "Reidja"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161080
+	1210.1.1 = {
+		birth = yes
+	}
+
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+161082 = {
+	name = "Sandaki"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161081
+	1240.1.1 = {
+		birth = yes
+	}
+
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+161083 = {
+	name = "Bada"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161082
+	1270.1.1 = {
+		birth = yes
+	}
+
+	1320.1.1 = {
+		death = yes
+	}
+}
+
+161084 = {
+	name = "Birama"
+	#placeholder
+	dynasty = 1030009
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161083
+	1300.1.1 = {
+		birth = yes
+	}
+
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+161085 = {
+	name = "Kayna"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	1050.1.1 = {
+		birth = yes
+	}
+
+	1110.1.1 = {
+		death = yes
+	}
+}
+
+161086 = {
+	name = "Bonga"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161085
+	1080.1.1 = {
+		birth = yes
+	}
+
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+161087 = {
+	name = "Majan"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161086
+	1110.1.1 = {
+		birth = yes
+	}
+
+	1170.1.1 = {
+		death = yes
+	}
+}
+
+161088 = {
+	name = "Mamadi"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161087
+	1150.1.1 = {
+		birth = yes
+	}
+
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+161089 = {
+	name = "Musa"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161088
+	1180.1.1 = {
+		birth = yes
+	}
+
+	1240.1.1 = {
+		death = yes
+	}
+}
+
+161090 = {
+	name = "Diara"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161089
+	1210.1.1 = {
+		birth = yes
+	}
+
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+161091 = {
+	name = "Sulayman"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161090
+	1240.1.1 = {
+		birth = yes
+	}
+
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+161092 = {
+	name = "Alayaman"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161091
+	1270.1.1 = {
+		birth = yes
+	}
+
+	1320.1.1 = {
+		death = yes
+	}
+}
+
+161093 = {
+	name = "Biyu"
+	#placeholder
+	dynasty = 1030010
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161092
+	1300.1.1 = {
+		birth = yes
+	}
+
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+161103 = {
+	name = "Kassa"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	1050.1.1 = {
+		birth = yes
+	}
+
+	1110.1.1 = {
+		death = yes
+	}
+}
+
+161104 = {
+	name = "Takoi"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161103
+	1080.1.1 = {
+		birth = yes
+	}
+
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+161105 = {
+	name = "Kanafa"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161104
+	1110.1.1 = {
+		birth = yes
+	}
+
+	1170.1.1 = {
+		death = yes
+	}
+}
+
+161106 = {
+	name = "Fatta"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161105
+	1150.1.1 = {
+		birth = yes
+	}
+
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+161107 = {
+	name = "Ouali"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161106
+	1180.1.1 = {
+		birth = yes
+	}
+
+	1240.1.1 = {
+		death = yes
+	}
+}
+
+161108 = {
+	name = "Fädazu"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161107
+	1210.1.1 = {
+		birth = yes
+	}
+
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+161109 = {
+	name = "Kaya"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161108
+	1240.1.1 = {
+		birth = yes
+	}
+
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+161110 = {
+	name = "Lahiltoul"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161109
+	1270.1.1 = {
+		birth = yes
+	}
+
+	1320.1.1 = {
+		death = yes
+	}
+}
+
+161111 = {
+	name = "Akoi"
+	#placeholder
+	dynasty = 1030012
+	religion = sunni
+	culture = maghreb_arabic
+	father = 161110
+	1300.1.1 = {
+		birth = yes
+	}
+
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+#rulers of Fezzan
+248788 = {
+	name = "Abdallah"	 #ibn Hiyân, historical ruler of Zawila d.762
+	dynasty = 1059964
+	religion = ibadi
+	culture = maghreb_arabic
+	720.1.1 = {
+		birth = yes
+	}
+	762.1.1 = {
+		death = yes
+	}
+}
+
+248789 = {
+	name = "Hiyan" #ibn AbdAlâh
+	dynasty = 1059964
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248788
+	745.1.1 = {
+		birth = yes
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+#Banú Khattâb in Fezzan
+248790 = {
+	name = "al-Khattab"  #semi-historical
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	850.1.1 = {
+		birth = yes
+	}
+	905.1.1 = {
+		death = yes
+	}
+}
+
+248791 = {
+	name = "Abdallah ibn al-Khattab al-Hawwari"  #historical founder of the Banu Khattâb tribe/dynasty lived in 918
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248790
+	880.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+248792 = {
+	name = "Abdallah"  #fictional son of historical founder of the Banu Khattâb tribe/dynasty
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248791
+	910.1.1 = {
+		birth = yes
+	}
+	970.1.1 = {
+		death = yes
+	}
+}
+
+248793 = {
+	name = "Thakiya" #placeholder
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248792
+	945.1.1 = {
+		birth = yes
+	}
+	1005.1.1 = {
+		death = yes
+	}
+}
+
+248794 = {
+	name = "Abdallah" #placeholder
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248793
+	980.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+248795 = {
+	name = "Isma'il" #placeholder
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248794
+	1015.1.1 = {
+		birth = yes
+	}
+	1064.1.1 = {
+		death = yes
+	}
+}
+
+248796 = {
+	name = "Thakiya" #placeholder
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248795
+	1040.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+248797 = {
+	name = "Abdallah"		  #placeholder
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248796
+	1072.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+248798 = {
+	name = "Hiyan"		  #placeholder
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248797
+	1100.1.1 = {
+		birth = yes
+	}
+	1162.1.1 = {
+		death = yes
+	}
+}
+
+248799 = {
+	name = "Musa"		  #placeholder
+	dynasty = 1059963
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 248798
+	1132.1.1 = {
+		birth = yes
+	}
+	1195.1.1 = {
+		death = yes # died five years earlier but extended slightly as there is no information between Banu Khattab and Karakush
+	}
+}
+
+## End of Fezzan rulers
+
+# Air rulers
+248800 = {
+	name = "Awdia"
+	dynasty = 1059961
+	religion = west_african_pagan
+	culture = maghreb_arabic # tuareg
+	trait = sympathy_islam
+	730.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+248801 = {
+	name = "Tacfin"
+	dynasty = 1059961
+	religion = west_african_pagan
+	culture = maghreb_arabic # tuareg
+	father = 248800
+	trait = sympathy_islam
+	769.1.1 = {
+		birth = yes
+	}
+	830.1.1 = {
+		death = yes
+	}
+}
+
+248802 = {
+	name = "Isli"
+	dynasty = 1059961
+	religion = west_african_pagan
+	culture = maghreb_arabic # tuareg
+	father = 248801
+	trait = sympathy_islam
+	800.1.1 = {
+		birth = yes
+	}
+	 870.1.1 = {
+		death = yes
+	}
+}
+
+248803 = {
+	name = "Agdun"
+	dynasty = 1059961
+	religion = west_african_pagan
+	culture = maghreb_arabic # tuareg
+	father = 248802
+	trait = sympathy_islam
+	850.1.1 = {
+		birth = yes
+	}
+	920.1.1 = {
+		death = yes # spread of Islam reprsented by change in dynasty
+	}
+}
+
+# Islam spreads to d_air
+248816 = {
+	name = "Jibril" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	trait = sympathy_pagans
+	1040.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+248804 = {
+	name = "Muhammad" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248816
+	trait = sympathy_pagans
+	1067.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+248805 = {
+	name = "Abu Bakr" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248804
+	trait = sympathy_pagans
+	1086.1.1 = {
+		birth = yes
+	}
+	1150.1.1 = {
+		death = yes
+	}
+}
+
+248806 = {
+	name = "Abdul-Haleem" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248805
+	trait = sympathy_pagans
+	1110.1.1 = {
+		birth = yes
+	}
+	1170.1.1 = {
+		death = yes
+	}
+}
+
+248807 = {
+	name = "Isa" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248806
+	trait = sympathy_pagans
+	1130.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+248808 = {
+	name = "Hassan" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248807
+	trait = sympathy_pagans
+	1150.1.1 = {
+		birth = yes
+	}
+	1220.1.1 = {
+		death = yes
+	}
+}
+
+248809 = {
+	name = "Mirza" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248808
+	trait = sympathy_pagans
+	1180.1.1 = {
+		birth = yes
+	}
+	1250.1.1 = {
+		death = yes
+	}
+}
+
+248810 = {
+	name = "Jabir" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248809
+	trait = sympathy_pagans
+	1200.1.1 = {
+		birth = yes
+	}
+	1270.1.1 = {
+		death = yes
+	}
+}
+
+248811 = {
+	name = "Burhanaddin" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248810
+	trait = sympathy_pagans
+	1220.1.1 = {
+		birth = yes
+	}
+	1290.1.1 = {
+		death = yes
+	}
+}
+
+248812 = {
+	name = "Uways" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248811
+	trait = sympathy_pagans
+	1240.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+248813 = {
+	name = "Seghada" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248812
+	trait = sympathy_pagans
+	1270.1.1 = {
+		birth = yes
+	}
+	1334.1.1 = {
+		death = yes
+	}
+}
+
+248814 = {
+	name = "Idris" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248813
+	trait = sympathy_pagans
+	1290.1.1 = {
+		birth = yes
+	}
+	1338.1.1 = {
+		death = yes
+	}
+}
+
+248815 = {
+	name = "Abdallah" # fictional
+	dynasty = 1059962
+	religion = sunni
+	culture = maghreb_arabic
+	father = 248814
+	trait = sympathy_pagans
+	1315.1.1 = {
+		birth = yes
+	}
+	1338.1.1 = {
+		death = yes
+	}
+}
+
+## End of Air rulers
+260859 = {
+	name = "Mukhtar"
+	dynasty = 1062441
+	religion = shiite
+	culture = maghreb_arabic
+	894.1.1 = {
+		birth = yes
+	}
+	938.1.1 = {
+		death = yes
+	}
+}
+
+260861 = {
+	name = "Abu Yazid"
+	dynasty = 1048004
+	religion = kharijite
+	culture = maghreb_arabic
+	873.1.1 = {
+		birth = yes
+	}
+	943.8.19 = {
+		death = yes
+	}
+}
+
+260862 = {
+	name = "Azrur"
+	dynasty = 1048004
+	religion = kharijite
+	culture = maghreb_arabic
+	father = 260861
+	901.1.1 = {
+		birth = yes
+	}
+	943.8.19 = {
+		death = yes
+	}
+}
+
+260863 = {
+	name = "Ahamatu"
+	dynasty = 1062443
+	religion = kharijite
+	culture = maghreb_arabic
+	895.1.1 = {
+		birth = yes
+	}
+	965.1.1 = {
+		death = yes
+	}
+}
+
+260864 = {
+	name = "Muhammad"
+	dynasty = 1062444
+	religion = ibadi
+	culture = maghreb_arabic
+	895.1.1 = {
+		birth = yes
+	}
+	943.1.1 = {
+		death = yes
+	}
+}
+
+260865 = {
+	name = "Samgu"
+	dynasty = 1062444
+	religion = ibadi
+	culture = maghreb_arabic
+	father = 260864
+	917.1.1 = {
+		birth = yes
+	}
+	943.1.1 = {
+		death = yes
+	}
+}
+
+260866 = {
+	name = "Agdada"
+	dynasty = 1062445
+	religion = shiite
+	culture = maghreb_arabic
+	892.1.1 = {
+		birth = yes
+	}
+	941.1.1 = {
+		death = yes
+	}
+}
+
+260867 = {
+	name = "Atissi"
+	dynasty = 1062446
+	religion = shiite
+	culture = maghreb_arabic
+	904.1.1 = {
+		birth = yes
+	}
+	951.1.1 = {
+		death = yes
+	}
+}
+
+260868 = {
+	name = "Amayas"
+	dynasty = 1062447
+	religion = shiite
+	culture = maghreb_arabic
+	901.1.1 = {
+		birth = yes
+	}
+	961.1.1 = {
+		death = yes
+	}
+}
+
+260869 = {
+	name = "Masmud"
+	dynasty = 1062448
+	religion = shiite
+	culture = maghreb_arabic
+	893.1.1 = {
+		birth = yes
+	}
+	947.1.1 = {
+		death = yes
+	}
+}
+
+260870 = {
+	name = "Awdia"
+	dynasty = 1059961
+	religion = west_african_pagan
+	culture = maghreb_arabic # tuareg
+	trait = sympathy_islam
+	father = 248803
+	884.1.1 = {
+		birth = yes
+	}
+	941.1.1 = {
+		death = yes
+	}
+}
+
+261371 = {
+	name = "Awdia"
+	dynasty = 1062604
+	culture = maghreb_arabic
+	religion = sunni
+	895.1.1 = {
+		birth = yes
+	}
+	945.1.1 = {
+		death = yes
+	}
+}
+
+261372 = {
+	name = "Masnsen"
+	dynasty = 1062604
+	culture = maghreb_arabic
+	religion = sunni
+	father = 261371
+	924.1.1 = {
+		birth = yes
+	}
+	976.1.1 = {
+		death = yes
+	}
+}
+
+261373 = {
+	name = "Adelah"
+	female = yes
+	dynasty = 1062604
+	culture = maghreb_arabic
+	religion = sunni
+	father = 261371
+	927.1.1 = {
+		birth = yes
+	}
+	981.1.1 = {
+		death = yes
+	}
+}
+
+261374 = {
+	name = "Ilyas"
+	dynasty = 1062604
+	culture = maghreb_arabic
+	religion = sunni
+	father = 261371
+	929.1.1 = {
+		birth = yes
+	}
+	995.1.1 = {
+		death = yes
+	}
+}
+
+# historical Lamtuna kings
+
+273070 = {
+	name = "Tîlutân" #ibn Tîklân
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = soninke
+	father = 273095
+	757.1.1 = {
+		birth = yes
+	}
+	763.1.1 = {
+		culture = maghreb_arabic #tagelmust
+	}
+	837.1.1 = {
+		death = yes
+	}
+}
+
+273071 = {
+	name = "Bâtin" #brother of Itlutân
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273095
+	769.1.1 = {
+		birth = yes
+	}
+	835.1.1 = {
+		death = yes
+	}
+}
+
+273072 = {
+	name = "al-Athîr" #ibn Bâtin
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273071
+	830.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+273073 = {
+	name = "Tamîm" #ibn al-Athîr
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273072
+	862.1.1 = {
+		birth = yes
+	}
+	918.1.1 = {
+		death = yes
+	}
+}
+
+273074 = {
+	name = "Nizâr"
+	dynasty = 1069084 #Ghusti 1069089
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273101
+	866.1.1 = {
+		birth = yes
+	}
+	909.1.1 = {
+		death = yes
+	}
+}
+
+273075 = {
+	name = "Wanshîk" #ibn Bizâr
+	dynasty = 1069084 #Ghusti
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273074
+	890.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+273076 = {
+	name = "Tinazwa" #ibn Wanshîk  #AKA Tîn Yarutân ibn Wisnâ ibn Nazâr
+	dynasty = 1069084 #Ghusti
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273075
+	925.1.1 = {
+		birth = yes
+	}
+	978.1.1 = {
+		death = yes
+	}
+}
+
+273077 = {
+	name = "Tifawt"
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273124 #should be somebody else
+	955.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+273078 = {
+	name = "Abu-Abd Allâh Muhammad" #ibn Tifawt
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273077
+	990.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		death = yes
+	}
+}
+
+273079 = {
+	name = "AbdAllâh" #ibn Muhammad"
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273078
+	1018.1.1 = {
+		birth = yes
+	}
+	1042.1.1 = { #?
+		death = yes
+	}
+}
+
+273081 = {
+	name = "Talakakin"
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	718.1.1 = {
+		birth = yes
+	}
+	764.1.1 = {
+		death = yes
+	}
+}
+
+273080 = {
+	name = "Keraja"
+	dynasty = 1069082 #Lamta
+	religion = ibadi
+	culture = maghreb_arabic #tagelmust
+	father = 273097
+	850.1.1 = {
+		birth = yes
+	}
+	901.1.1 = {
+		death = yes
+	}
+}
+
+273083 = {
+	name = "Abd Allah ibn Yasin"
+	dynasty = 1069087
+	martial = 7
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 7
+	learning = 6
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	add_trait = zealous
+	add_trait = diligent
+	add_trait = just
+	add_trait = scholarly_theologian
+	1003.1.1 = {
+		birth = yes
+	}
+	1057.1.1 = {
+		employer = 3853
+	}
+	1059.1.1 = {
+		death = yes
+	}
+}
+
+273084 = {
+	name = "Talalit" #name fictional
+	female = yes
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273077
+	993.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		add_spouse = 273122
+	}
+	1050.1.1 = {
+		death = yes
+	}
+}
+
+273085 = {
+	name = "Ibrahim"
+	dynasty = 1069084
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273105
+	980.1.1 = {
+		birth = yes
+	}
+	1025.1.1 = {
+		death = yes
+	}
+}
+
+273086 = {
+	name = "Tamim" #fictional son of Yahya ibn Ibrahim
+	dynasty = 1069084
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273122
+	mother = 273084
+	1021.1.1 = {
+		birth = yes
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+273087 = {
+	name = "Ali"
+	dynasty = 1069080
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 32958
+	1048.1.1 = {
+		birth = yes
+	}
+	1053.1.1 = {
+		dynasty = 7274
+	}
+	1099.1.1 = {
+		death = yes
+	}
+}
+
+273088 = {
+	name = "'Abu-Umar"
+	dynasty = 1069081
+	religion = shiite
+	culture = maghreb_arabic #tagelmust
+	father = 1144550
+	1060.1.1 = {
+		birth = yes
+	}
+	1101.1.1 = {
+		death = yes
+	}
+}
+
+273089 = {
+	#placeholder
+	name = "Atissi"
+	dynasty = 1069082 #Lamta
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273080
+	873.1.1 = {
+		birth = yes
+	}
+	926.1.1 = {
+		death = yes
+	}
+}
+
+273090 = {
+	#placeholder
+	name = "Kadidu"
+	dynasty = 1069082 #Lamta
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273089
+	900.1.1 = {
+		birth = yes
+	}
+	964.1.1 = {
+		death = yes
+	}
+}
+
+273091 = {
+	#placeholder
+	name = "Tiljad"
+	dynasty = 1069082 #Lamta
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273090
+	923.1.1 = {
+		birth = yes
+	}
+	981.1.1 = {
+		death = yes
+	}
+}
+
+273092 = {
+	#placeholder
+	name = "Watt'as"
+	dynasty = 1069082 #Lamta
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273091
+	949.1.1 = {
+		birth = yes
+	}
+	1002.1.1 = {
+		death = yes
+	}
+}
+
+273093 = {
+	#placeholder
+	name = "Kussil"
+	dynasty = 1069082 #Lamta
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273092
+	975.1.1 = {
+		birth = yes
+	}
+	1036.1.1 = {
+		death = yes
+	}
+}
+
+273094 = {
+	#placeholder
+	name = "Ibiza"
+	dynasty = 1069082 #Lamta
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273093
+	1006.1.1 = {
+		birth = yes
+	}
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+273095 = {
+	name = "Tîklân al-Lamtunî"
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = soninke
+	father = 273081
+	738.1.1 = {
+		birth = yes
+	}
+	763.1.1 = {
+		culture = maghreb_arabic #tagelmust
+	}
+	768.1.1 = {
+		death = yes
+	}
+}
+
+273096 = {
+	#placeholder
+	name = "Ghida"
+	female = yes
+	dynasty = 1069082
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273097
+	849.1.1 = {
+		birth = yes
+	}
+	865.1.1 = {
+		add_spouse = 273098
+	}
+	903.1.1 = {
+		death = yes
+	}
+}
+
+273097 = {
+	#placeholder
+	name = "Tiljad"
+	dynasty = 1069082
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273106
+	822.1.1 = {
+		birth = yes
+	}
+	882.1.1 = {
+		death = yes
+	}
+}
+
+273098 = {
+	#placeholder
+	name = "Bezz'i"
+	dynasty = 1069083 #Tamtust
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	834.1.1 = {
+		birth = yes
+	}
+	865.1.1 = {
+		add_spouse = 273096
+	}
+	880.1.1 = {
+		death = yes
+	}
+}
+
+273099 = {
+	#placeholder
+	name = "Yahya"
+	dynasty = 1069083 #Tamtust
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273098
+	853.1.1 = {
+		birth = yes
+	}
+	901.1.1 = {
+		death = yes
+	}
+}
+
+273100 = {
+	#placeholder
+	name = "Tamrust"
+	female = yes
+	dynasty = 1069083 #Tamtust
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273098
+	850.1.1 = {
+		birth = yes
+	}
+	866.1.1 = {
+		add_spouse = 273101
+	}
+	903.1.1 = {
+		death = yes
+	}
+}
+
+273101 = {
+	#placeholder
+	name = "Watt'as"
+	dynasty = 1069084  #Guddála
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	848.1.1 = {
+		birth = yes
+	}
+	866.1.1 = {
+		add_spouse = 273100
+	}
+	899.1.1 = {
+		death = yes
+	}
+}
+
+273102 = {
+	#placeholder
+	name = "Tamrust"
+	female = yes
+	dynasty = 1069084
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273101
+	866.10.10 = {
+		birth = yes
+	}
+	918.1.1 = {
+		death = yes
+	}
+}
+
+273103 = {
+	#placeholder
+	name = "Tamim"
+	dynasty = 1069084  #Guddála
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273101
+	878.1.1 = {
+		birth = yes
+	}
+	932.1.1 = {
+		death = yes
+	}
+}
+
+273104 = {
+	#placeholder
+	name = "Watt'as"
+	dynasty = 1069084  #Guddála
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273103
+	910.1.1 = {
+		birth = yes
+	}
+	973.1.1 = {
+		death = yes
+	}
+}
+
+273105 = {
+	#placeholder
+	name = "Tamim"
+	dynasty = 1069084  #Guddála
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273104
+	943.1.1 = {
+		birth = yes
+	}
+	1009.1.1 = {
+		death = yes
+	}
+}
+
+273106 = {
+	#placeholder
+	name = "Ashraf"
+	dynasty = 1069082
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273107
+	782.1.1 = {
+		birth = yes
+	}
+	850.1.1 = {
+		death = yes
+	}
+}
+
+273107 = {
+	#placeholder
+	name = "Abu Lamta"
+	dynasty = 1069082
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	753.1.1 = {
+		birth = yes
+	}
+	812.1.1 = {
+		death = yes
+	}
+}
+
+273108 = {
+	name = "Yahya" #al-Massufi, son of Abu Bakr, ruler of Saharan Almoravids
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 3853
+	mother = 273120
+	1055.1.1 = {
+		birth = yes
+	}
+	1112.1.1 = {
+		death = yes
+	}
+}
+
+273109 = {
+	name = "Ibrahim" # son of Abu Bakr, ruled in Sijilmasa
+	dynasty = 7274
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 3853
+	mother = 273120
+	1053.1.1 = {
+		birth = yes
+	}
+	1105.1.1 = {
+		death = yes
+	}
+}
+
+# Tribal leaders
+273110 = {
+	name = "Awzal"
+	dynasty = 1069088 # Massufa tribe
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273112
+	846.4.4 = {
+		birth = yes
+	}
+	900.6.6 = {
+		death = yes
+	}
+}
+
+273111 = {
+	name = "Yabdas"
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273110
+	866.4.4 = {
+		birth = yes
+	}
+	922.6.6 = {
+		death = yes
+	}
+}
+
+273112 = {
+	name = "Mazigh"
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic
+	826.4.4 = {
+		birth = yes
+	}
+	866.6.6 = {
+		death = yes
+	}
+}
+
+273113 = {
+	name = "Tayyurt"
+	female = yes
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic
+	father = 273112
+	847.4.4 = {
+		birth = yes
+	}
+	908.6.6 = {
+		death = yes
+	}
+}
+
+273114 = {
+	name = "Myassa"
+	female = yes
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic
+	father = 273112
+	849.10.4 = {
+		birth = yes
+	}
+	902.6.6 = {
+		death = yes
+	}
+}
+
+273115 = {
+	name = "Awzal"
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273111
+	894.4.4 = {
+		birth = yes
+	}
+	950.6.6 = {
+		death = yes
+	}
+}
+
+273116 = {
+	name = "Wattas"
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273115
+	923.4.4 = {
+		birth = yes
+	}
+	975.6.6 = {
+		death = yes
+	}
+}
+
+273117 = {
+	name = "Sakkum"
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273116
+	959.4.4 = {
+		birth = yes
+	}
+	1012.6.6 = {
+		death = yes
+	}
+}
+
+273118 = {
+	name = "Wattas"
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273117
+	993.4.4 = {
+		birth = yes
+	}
+	1051.6.6 = {
+		death = yes
+	}
+}
+
+273119 = {
+	name = "Tilankan"
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273118
+	1029.4.4 = {
+		birth = yes
+	}
+	1087.6.6 = {
+		death = yes
+	}
+}
+
+273120 = {
+	name = "Tarifa"
+	female = yes
+	dynasty = 1069088
+	religion = kharijite
+	culture = maghreb_arabic #tagelmust
+	father = 273118
+	1032.4.4 = {
+		birth = yes
+	}
+	1052.1.1 = {
+		add_spouse = 3853
+		religion = sunni
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+273121 = {
+	name = "Ibrahim"
+	dynasty = 1069084
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273076
+	960.1.1 = {
+		birth = yes
+	}
+	1029.1.1 = {
+		death = yes
+	}
+}
+
+273122 = {
+	name = "Yahya"
+	dynasty = 1069084
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273121
+	995.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		add_spouse = 273084
+	}
+	1043.1.1 = {
+		death = yes
+	}
+}
+
+273123 = {
+	name = "Addu" #fictional son of Tamîm ibn al-Athîr
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273073
+	895.1.1 = {
+		birth = yes
+	}
+	953.1.1 = {
+		death = yes
+	}
+}
+
+273124 = {
+	name = "Talakakin" #fictional placeholder to link Lamtuna with Almoravids
+	dynasty = 1069080 #Lamtuna
+	religion = sunni
+	culture = maghreb_arabic #tagelmust
+	father = 273123
+	932.1.1 = {
+		birth = yes
+	}
+	999.1.1 = {
+		death = yes
+	}
+}
+
+#Mazata chieftans
+273125 = {
+	name = "Abd-al-A'lâ" #Abu_l-Khattáb ibn al-Samh al Ma'afiri
+	dynasty = 1069090
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273126
+	723.1.1 = {
+		birth = yes
+	}
+	761.1.1 = {
+		death = yes
+	}
+}
+
+273126 = {
+	name = "al-Samh" #al-Ma'afiri
+	dynasty = 1069090
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	700.1.1 = {
+		birth = yes
+	}
+	757.1.1 = {
+		death = yes
+	}
+}
+
+273127 = {
+	name = "al-Khattab"
+	dynasty = 1069090
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273125
+	746.1.1 = {
+		birth = yes
+	}
+	809.1.1 = {
+		death = yes
+	}
+}
+
+273128 = {
+	name = "Dunas" #ibn al-Khayr al-Mazati 1100-1145 Mazati chieftan under Banu Khazrun
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273129
+	1080.1.1 = {
+		birth = yes
+	}
+	1145.1.1 = {
+		death = yes
+	}
+}
+
+273129 = {
+	name = "al-Khayr"
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273130
+	1050.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+273130 = {
+	name = "Arjân" #fictional
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273131
+	1016.1.1 = {
+		birth = yes
+	}
+	1064.1.1 = {
+		death = yes
+	}
+}
+
+273131 = {
+	name = "al-Samh" #fictional
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273132
+	983.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+273132 = {
+	name = "al-Khayr" #fictional
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273133
+	948.1.1 = {
+		birth = yes
+	}
+	1009.1.1 = {
+		death = yes
+	}
+}
+
+273133 = {
+	name = "Dunas" #fictional
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273134
+	915.1.1 = {
+		birth = yes
+	}
+	970.1.1 = {
+		death = yes
+	}
+}
+
+273134 = {
+	name = "Arjân" #fictional
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273135
+	880.1.1 = {
+		birth = yes
+	}
+	933.1.1 = {
+		death = yes
+	}
+}
+
+273135 = {
+	name = "al-Khayr" #fictional
+	dynasty = 1069091 #al-Mazâtî
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	847.1.1 = {
+		birth = yes
+	}
+	903.1.1 = {
+		death = yes
+	}
+}
+
+#Hawwára in Tripolitania
+273136 = {
+	name = "AbdAllâh"  #placeholder
+	dynasty = 1069092
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	832.1.1 = {
+		birth = yes
+	}
+	866.10.10 = {
+		death = yes
+	}
+}
+
+273137 = {
+	name = "Zalghîn"  #placeholder
+	dynasty = 1069092
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273136
+	850.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+273138 = {
+	name = "Kenwa"  #placeholder
+	female = yes
+	dynasty = 1069092
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273136
+	849.1.1 = {
+		birth = yes
+	}
+	903.1.1 = {
+		death = yes
+	}
+}
+
+273139 = {
+	name = "Azim"  #placeholder
+	dynasty = 1069092
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273137
+	888.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+273140 = {
+	name = "Zalghîn"  #placeholder
+	dynasty = 1069092
+	religion = ibadi
+	culture = maghreb_arabic #zanata
+	father = 273139
+	920.1.1 = {
+		birth = yes
+	}
+	976.1.1 = {
+		death = yes
+	}
+}

--- a/CK2Plus_expanded/history/characters/persian.txt
+++ b/CK2Plus_expanded/history/characters/persian.txt
@@ -1,0 +1,8638 @@
+6896 = {
+	name = "Mahmud" # Fantasy
+	dynasty = 855
+	religion = sunni
+	culture = persian
+	845.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+6897 = {
+	name = "Farroukh" # Fantasy
+	dynasty = 856
+	religion = sunni
+	culture = persian
+	840.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+6898 = {
+	name = "Abolhassan" # Fantasy
+	dynasty = 857
+	religion = sunni
+	culture = persian
+	842.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+144140 = {
+	name = "Muhammad"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93139
+	1113.1.1 = {
+		birth = yes
+	}
+	1163.1.1 = {
+		death = yes
+	}
+}
+
+144141 = {
+	name = "Ghiyath"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 144140
+	1130.1.1 = {
+		birth = yes
+	}
+	1203.1.1 = {
+		death = yes
+	}
+}
+
+144142 = {
+	name = "Mu'izz"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 144140
+	1132.1.1 = {
+		birth = yes
+	}
+	1206.3.15 = {
+		death = yes
+	}
+}
+
+144143 = {
+	name = "Mahmud"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 144141
+	1147.1.1 = {
+		birth = yes
+	}
+	1212.1.1 = {
+		death = yes
+	}
+}
+
+144144 = {
+	name = "Gilan-Shah"
+	# AKA: Unsur al
+	dynasty = 101689
+	martial = 7
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = persian
+	father = 20703
+	1061.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+
+144225 = {
+	name = "Hassan"
+	religion = shiite
+	culture = persian
+	1050.1.1 = {
+		birth = yes
+	}
+	1124.1.1 = {
+		death = yes
+	}
+}
+
+144226 = {
+	name = "Kiya Buzurg Ummid"
+	religion = shiite
+	culture = persian
+	1070.1.1 = {
+		birth = yes
+	}
+	1138.1.1 = {
+		death = yes
+	}
+}
+
+144227 = {
+	name = "Muhammad"
+	religion = shiite
+	culture = persian
+	1100.1.1 = {
+		birth = yes
+	}
+	1162.1.1 = {
+		death = yes
+	}
+}
+
+144228 = {
+	name = "Nur al-Din Muhammed"
+	religion = shiite
+	culture = persian
+	1130.1.1 = {
+		birth = yes
+	}
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+144229 = {
+	name = "Jalal al-Din Hasan"
+	religion = shiite
+	culture = persian
+	1170.1.1 = {
+		birth = yes
+	}
+	1221.1.1 = {
+		death = yes
+	}
+}
+
+144230 = {
+	name = "'Ala al-Din Muhammad"
+	religion = shiite
+	culture = persian
+	1190.1.1 = {
+		birth = yes
+	}
+	1255.1.1 = {
+		death = yes
+	}
+}
+
+144231 = {
+	name = "Rukn al-Din Khurshah"
+	religion = shiite
+	culture = persian
+	1210.1.1 = {
+		birth = yes
+	}
+	1256.1.1 = {
+		death = yes
+	}
+}
+
+144567 = {
+	name = "Afridun"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 20734
+	1058.1.1 = {
+		birth = yes
+	}
+	1120.1.1 = {
+		death = yes
+	}
+}
+
+144568 = {
+	name = "Akhsitan"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	trait = ambitious
+	trait = deceitful
+	trait = envious
+	trait = diligent
+	father = 232753
+	mother = 232750
+	1128.1.1 = {
+		birth = yes
+	}
+	1197.1.1 = {
+		death = yes
+	}
+}
+
+144569 = {
+	name = "Farrukhzad"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 232753
+	mother = 232750
+	1138.1.1 = {
+		birth = yes
+	}
+	1204.8.1 = {
+		death = yes
+	}
+}
+
+144570 = {
+	name = "Gushtasb"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144569
+	1171.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+144571 = {
+	name = "Fariburz"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144570
+	1192.1.1 = {
+		birth = yes
+	}
+	1243.1.1 = {
+		death = yes
+	}
+}
+
+144572 = {
+	name = "Akhsitan"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144571
+	1210.1.1 = {
+		birth = yes
+	}
+	1260.1.1 = {
+		death = yes
+	}
+}
+
+144573 = {
+	name = "Farrukhzad"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144572
+	1229.1.1 = {
+		birth = yes
+	}
+	1282.1.1 = {
+		death = yes
+	}
+}
+
+144574 = {
+	name = "Keykubad"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144573
+	1279.1.1 = {
+		birth = yes
+	}
+	1348.1.1 = {
+		death = yes
+	}
+}
+
+20688 = {
+	name = "Umar"
+	dynasty = 101004
+	martial = 8
+	diplomacy = 8
+	intrigue = 8
+	stewardship = 7
+	religion = sunni
+	culture = persian
+	trait = charitable
+	trait = kind
+	trait = martial_cleric
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20703 = {
+	name = "Keikavus"
+	dynasty = 101689
+	martial = 7
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 7
+	religion = sunni
+	culture = persian
+	father = 166996
+	trait = thrifty_clerk
+	trait = administrator
+	trait = poet
+	trait = temperate
+	trait = sympathy_zoroastrianism
+	1021.1.1 = {
+		birth = yes
+	}
+	1087.1.1 = {
+		death = yes
+	}
+}
+
+220996 = {
+	name = "Shahriyar"
+	dynasty = 7331
+	father = 160295
+	martial = 5
+	diplomacy = 4
+	intrigue = 3
+	stewardship = 8
+	trait = thrifty_clerk
+	trait = charitable
+	religion = zoroastrian
+	culture = persian
+	897.7.19 = {
+		birth = yes
+	}
+	970.12.10 = {
+		death = yes
+	}
+}
+
+220995 = {
+	name = "Rostam"
+	dynasty = 7331
+	father = 160295
+	martial = 7
+	diplomacy = 3
+	intrigue = 8
+	stewardship = 4
+	trait = tough_soldier
+	trait = arbitrary
+	religion = shiite
+	culture = persian
+	901.2.28 = {
+		birth = yes
+	}
+	979.10.12 = {
+		death = yes
+	}
+}
+
+220994 = {
+	name = "Al-Marzuban"
+	dynasty = 7331
+	father = 220995
+	martial = 2
+	diplomacy = 4
+	intrigue = 3
+	stewardship = 6
+	learning = 9
+	trait = charismatic_negotiator
+	trait = just
+	religion = shiite
+	culture = persian
+	931.9.12 = {
+		birth = yes
+	}
+	1006.10.12 = {
+		death = yes
+	}
+}
+
+220992 = {
+	name = "Vandarin"
+	dynasty = 7331
+	father = 220995 #fictional connection
+	martial = 4
+	diplomacy = 5
+	intrigue = 7
+	stewardship = 2
+	learning = 2
+	trait = charismatic_negotiator
+	trait = kind
+	religion = shiite
+	culture = persian
+	934.9.12 = {
+		birth = yes
+	}
+	997.10.12 = {
+		death = yes
+	}
+}
+
+220993 = {
+	name = "Abu Ja'far Muhammad"
+	dynasty = 7331
+	father = 220992
+	martial = 2
+	diplomacy = 8
+	intrigue = 4
+	stewardship = 6
+	learning = 4
+	trait = charismatic_negotiator
+	trait = honest
+	religion = shiite
+	culture = persian
+	964.4.20 = {
+		birth = yes
+	}
+	1029.11.21 = {
+		death = yes
+	}
+}
+
+220991 = {
+	name = "Sharyab" #Fictional character
+	dynasty = 7331
+	father = 220992
+	martial = 2
+	diplomacy = 2
+	intrigue = 3
+	stewardship = 1
+	learning = 1
+	trait = indulgent_wastrel
+	religion = shiite
+	culture = persian
+	971.8.12 = {
+		birth = yes
+	}
+	1062.11.9 = {
+		death = yes
+	}
+}
+
+20704 = {
+	name = "Qarin"
+	dynasty = 7331
+	father = 220991
+	martial = 7
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 7
+	religion = shiite
+	culture = persian
+	trait = tough_soldier
+	trait = zealous
+	trait = patient
+	trait = content
+	trait = honest
+	disallow_random_traits = yes
+	1031.1.1 = {
+		birth = yes
+	}
+	1074.1.1 = {
+		death = yes
+	}
+}
+
+20705 = {
+	name = "Isa"
+	dynasty = 101008
+	martial = 6
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 7
+	religion = sunni
+	culture = persian
+	trait = martial_cleric
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20707 = {
+	name = "Nasr"
+	dynasty = 101863
+	martial = 5
+	diplomacy = 8
+	intrigue = 5
+	stewardship = 4
+	religion = sunni
+	culture = persian
+	trait = deceitful
+	trait = amateurish_plotter
+	1039.1.1 = {
+		birth = yes
+	}
+	1089.1.1 = {
+		death = yes
+	}
+}
+
+20716 = {
+	name = "Musafir"
+	dynasty = 101870
+	martial = 5
+	diplomacy = 8
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = persian
+	trait = patient
+	trait = skilled_tactician
+	1040.1.1 = {
+		birth = yes
+	}
+	1095.1.1 = {
+		death = yes
+	}
+}
+
+20734 = {
+	name = "Fariburz"
+	dynasty = 101873
+	martial = 5
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 4
+	religion = sunni
+	culture = persian
+	trait = underhanded_rogue
+	father = 146101
+	1031.1.1 = {
+		birth = yes
+	}
+	1096.1.1 = {
+		death = yes
+	}
+}
+
+227012 = {
+	name = "Sinan"
+	dynasty = 100765
+	martial = 5
+	diplomacy = 4
+	intrigue = 6
+	stewardship = 8
+	religion = shiite
+	culture = persian
+	trait = diligent
+	trait = zealous
+	trait = skilled_tactician
+	1129.1.1 = {
+		birth = yes
+	}
+	1192.1.1 = {
+		death = yes
+	}
+}
+
+3050 = {
+	name = "Hassan"
+	dynasty = 611
+	martial = 6
+	diplomacy = 7
+	intrigue = 8
+	stewardship = 9
+	religion = sunni
+	culture = persian
+	trait = patient
+	trait = genius
+	trait = scholar
+	trait = ambitious
+	trait = just
+	trait = grey_eminence
+	1018.4.10 = {
+		birth = yes
+	}
+	1063.9.4 = {
+		employer = 3040
+		effect = {
+			give_job_title = job_chancellor
+		}
+	}
+	1092.10.14 = {
+		death = yes
+	}
+}
+
+41606 = {
+	name = "Shariyar" # IV
+	# AKA: Husam ud
+	dynasty = 7331
+	martial = 3
+	diplomacy = 2
+	intrigue = 7
+	stewardship = 4
+	religion = shiite
+	culture = persian
+	trait = thrifty_clerk
+	father = 20704
+	1057.1.1 = {
+		birth = yes
+	}
+	1114.1.1 = {
+		death = yes
+	}
+}
+
+41607 = {
+	name = "Fadlun" #P'atlun
+	dynasty = 1029026
+	martial = 8
+	diplomacy = 3
+	intrigue = 2
+	stewardship = 7
+	religion = sunni
+	culture = persian
+	trait = tough_soldier
+	1028.1.1 = {
+		birth = yes
+	}
+	1088.1.1 = {
+		death = yes
+	}
+}
+
+41608 = {
+	name = "Srahang"
+	dynasty = 1029026
+	martial = 9
+	diplomacy = 4
+	intrigue = 2
+	stewardship = 8
+	religion = sunni
+	culture = persian
+	trait = tough_soldier
+	father = 41607
+	1060.1.1 = {
+		birth = yes
+	}
+	1122.1.1 = {
+		death = yes
+	}
+}
+
+#41702 = {
+#	name = "Hassan"
+#	dynasty = 101728
+#	martial = 6
+#	diplomacy = 6
+#	intrigue = 10
+#	stewardship = 7
+#	religion = sunni
+#	culture = persian
+#	trait = zealous
+#	trait = elusive_shadow
+#	1035.1.2 = {
+#		birth = yes
+#	}
+#	1085.1.2 = {
+#		death = yes
+#	}
+#}
+
+41703 = {
+	name = "Omar"
+	dynasty = 101729
+	martial = 3
+	diplomacy = 10
+	intrigue = 6
+	stewardship = 5
+	religion = sunni
+	culture = persian
+	trait = lustful
+	trait = charismatic_negotiator
+	1048.1.2 = {
+		birth = yes
+	}
+	1098.1.2 = {
+		death = yes
+	}
+}
+
+478020 = {
+	name = "Muhammad"
+	dynasty = 100657
+	martial = 5
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = persian
+	trait = ambitious
+	trait = charismatic_negotiator
+	trait = charitable
+	1315.1.1 = {
+		birth = yes
+	}
+	1365.1.1 = {
+		death = yes
+	}
+}
+
+478021 = {
+	name = "Yusuf"
+	dynasty = 100648
+	martial = 7
+	diplomacy = 5
+	intrigue = 6
+	stewardship = 5
+	religion = sunni
+	culture = persian
+	trait = ambitious
+	trait = tough_soldier
+	trait = kind
+	trait = just
+	1296.1.1 = {
+		birth = yes
+	}
+	1346.1.1 = {
+		death = yes
+	}
+}
+
+478022 = {
+	name = "Mubariz ad-Din"
+	dynasty = 101915
+	martial = 10
+	diplomacy = 7
+	intrigue = 5
+	stewardship = 6
+	religion = sunni
+	culture = persian
+	trait = ambitious
+	trait = skilled_tactician
+	trait = envious
+	father = 93268
+	1295.1.1 = {
+		birth = yes
+	}
+	1358.1.1 = {
+		death = yes
+	}
+}
+
+478023 = {
+	name = "Qutb al-Din"
+	dynasty = 101915
+	martial = 6
+	diplomacy = 6
+	intrigue = 7
+	stewardship = 5
+	religion = sunni
+	culture = persian
+	trait = tough_soldier
+	trait = proud
+	father = 478022
+	1315.1.1 = {
+		birth = yes
+	}
+	1375.1.1 = {
+		death = yes
+	}
+}
+
+478024 = {
+	name = "Abul Fawaris Djamal ad-Din"
+	# AKA: Abul Fawaris
+	dynasty = 101915
+	martial = 6
+	diplomacy = 6
+	intrigue = 3
+	stewardship = 7
+	religion = sunni
+	culture = persian
+	trait = underhanded_rogue
+	trait = wroth
+	father = 478022
+	1317.1.1 = {
+		birth = yes
+	}
+	1364.1.1 = {
+		death = yes
+	}
+}
+
+478027 = {
+	name = "Ali"
+	dynasty = 100632
+	martial = 3
+	diplomacy = 7
+	intrigue = 4
+	stewardship = 8
+	religion = sunni
+	culture = persian
+	trait = thrifty_clerk
+	trait = greedy
+	1300.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+478028 = {
+	name = "Abdullah"
+	dynasty = 100635
+	martial = 6
+	diplomacy = 6
+	intrigue = 5
+	stewardship = 7
+	religion = sunni
+	culture = persian
+	trait = misguided_warrior
+	trait = wroth
+	1305.1.1 = {
+		birth = yes
+	}
+	1355.1.1 = {
+		death = yes
+	}
+}
+
+45100 = {
+	name = "Abdal-Razzaq"
+	dynasty = 7507
+	martial = 6
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 8
+	religion = shiite
+	culture = persian
+	trait = just
+	trait = wroth
+	trait = stressed
+	trait = skilled_tactician
+	father = 45102
+	1300.1.1 = {
+		birth = yes
+	}
+	1338.1.1 = {
+		death = yes
+	}
+}
+
+45101 = {
+	name = "Masud"
+	dynasty = 7507
+	martial = 3
+	diplomacy = 8
+	intrigue = 7
+	stewardship = 6
+	religion = shiite
+	culture = persian
+	trait = craven
+	trait = content
+	trait = wroth
+	trait = charismatic_negotiator
+	father = 45102
+	1301.1.1 = {
+		birth = yes
+	}
+	1343.1.1 = {
+		death = yes
+	}
+}
+
+45102 = {
+	name = "Fazlullah"
+	dynasty = 7507
+	martial = 4
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 6
+	religion = shiite
+	culture = persian
+	trait = detached_priest
+	1275.1.1 = {
+		birth = yes
+	}
+	1335.1.1 = {
+		death = yes
+	}
+}
+
+45106 = {
+	name = "Faraz" # Fantasy Zoroastrian ruler near Bukhara
+	dynasty = 7510 # Faravid
+	martial = 7
+	diplomacy = 4
+	intrigue = 5
+	stewardship = 7
+	religion = zoroastrian
+	culture = persian
+	trait = tough_soldier
+	849.1.1 = {
+		birth = yes
+	}
+	899.1.1 = {
+		death = yes
+	}
+}
+
+45107 = {
+	name = "Vandad" # Fictional leader of the House of Karen at the time
+	dna = xqndnvqyari
+	properties = fo0edd000000000000
+	dynasty = 7511 # Karen
+	martial = 7
+	diplomacy = 5
+	intrigue = 5
+	stewardship = 4
+	religion = zoroastrian
+	culture = persian
+	trait = tough_soldier
+	father = 45110
+	830.1.1 = {
+		birth = yes
+	}
+
+	867.1.1 = {
+		# The last hope of the Zoroastrians
+		effect = {
+			spawn_unit = {
+				province = 633 # Gurgan
+				owner = ROOT
+				#leader = ROOT
+				troops = {
+					light_infantry = { 625 625 }
+					heavy_infantry = { 479 479 }
+					pikemen = { 30 30 }
+					archers = { 254 254 }
+					light_cavalry = { 132 132 }
+					knights = { 4 4 }
+					horse_archers = { 12 12 }
+				}
+				attrition = 0.5
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 23
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 633 # Gurgan
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 625 625 }
+						heavy_infantry = { 479 479 }
+						pikemen = { 30 30 }
+						archers = { 254 254 }
+						light_cavalry = { 132 132 }
+						knights = { 4 4 }
+						horse_archers = { 12 12 }
+					}
+					attrition = 0.5
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 27
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 633 # Gurgan
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 625 625 }
+						heavy_infantry = { 479 479 }
+						pikemen = { 30 30 }
+						archers = { 254 254 }
+						light_cavalry = { 132 132 }
+						knights = { 4 4 }
+						horse_archers = { 12 12 }
+					}
+					attrition = 0.5
+				}
+			}
+		}
+	}
+
+	890.1.1 = {
+		death = yes
+	}
+}
+
+45109 = {
+	name = "Farah" # Fictional
+	female = yes
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 45110
+	835.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+45110 = {
+	name = "Mazyar" # Historical. Died in revolt against the Caliph
+	dynasty = 7511
+	martial = 7
+	religion = zoroastrian
+	culture = persian
+	trait = skilled_tactician
+	father = 160296
+	800.1.1 = {
+		birth = yes
+	}
+	839.1.1 = {
+		death = yes
+	}
+}
+
+93010 = {
+	name = "Hashim"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	835.1.1 = {
+		birth = yes
+	}
+
+	885.1.1 = {
+		death = yes
+	}
+}
+
+93011 = {
+	name = "'Amr"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93010
+	855.1.1 = {
+		birth = yes
+	}
+
+	886.1.1 = {
+		death = yes
+	}
+}
+
+93012 = {
+	name = "Muhammad"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93011
+	871.1.1 = {
+		birth = yes
+	}
+
+	915.1.1 = {
+		death = yes
+	}
+}
+
+93013 = {
+	name = "Abdul Malik"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93012
+	890.1.1 = {
+		birth = yes
+	}
+
+	939.1.1 = {
+		death = yes
+	}
+}
+
+93014 = {
+	name = "Ahmad"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93013
+	910.1.1 = {
+		birth = yes
+	}
+
+	976.1.1 = {
+		death = yes
+	}
+}
+
+93015 = {
+	name = "Maimun"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93014
+	940.1.1 = {
+		birth = yes
+	}
+
+	997.1.1 = {
+		death = yes
+	}
+}
+
+93016 = {
+	name = "Muhammad"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93014
+	942.1.1 = {
+		birth = yes
+	}
+
+	998.1.1 = {
+		death = yes
+	}
+}
+
+93017 = {
+	name = "Lashkari"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93014
+	946.1.1 = {
+		birth = yes
+	}
+
+	1001.1.1 = {
+		death = yes
+	}
+}
+
+93018 = {
+	name = "al-Mansur"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93017
+	970.1.1 = {
+		birth = yes
+	}
+
+	1034.1.1 = {
+		death = yes
+	}
+}
+
+93019 = {
+	name = "Abdul Malik"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93018
+	990.1.1 = {
+		birth = yes
+	}
+	1035.12.1 = {
+		add_spouse = 146102
+	}
+	1043.1.1 = {
+		death = yes
+	}
+}
+
+93020 = {
+	name = "al-Mansur"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93019
+	1010.1.1 = {
+		birth = yes
+	}
+
+	1065.1.1 = {
+		death = yes
+	}
+}
+
+93021 = {
+	name = "Lashkari"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93019
+	1015.1.1 = {
+		birth = yes
+	}
+
+	1055.1.1 = {
+		death = yes
+	}
+}
+
+93022 = {
+	name = "Abdul Malik"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93020
+	1030.1.1 = {
+		birth = yes
+	}
+
+	1075.1.1 = {
+		death = yes
+	}
+}
+
+93023 = {
+	name = "Maimum"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93022
+	1050.1.1 = {
+		birth = yes
+	}
+
+	1077.1.1 = {
+		death = yes
+	}
+}
+
+93024 = {
+	name = "Khalifa"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93023
+	1070.1.1 = {
+		birth = yes
+	}
+
+	1120.1.1 = {
+		death = yes
+	}
+}
+
+93025 = {
+	name = "Muhammad"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93024
+	1095.1.1 = {
+		birth = yes
+	}
+
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+93026 = {
+	name = "Muzaffar"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93025
+	1115.1.1 = {
+		birth = yes
+	}
+
+	1165.1.1 = {
+		death = yes
+	}
+}
+
+93027 = {
+	name = "Begbars"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93026
+	1135.1.1 = {
+		birth = yes
+	}
+
+	1190.1.1 = {
+		death = yes
+	}
+}
+
+93028 = {
+	name = "Abdul Malik"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93027
+	1155.1.1 = {
+		birth = yes
+	}
+
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+93029 = {
+	name = "Rashid"
+	dynasty = 7326
+	religion = sunni
+	culture = persian
+	father = 93028
+	1180.1.1 = {
+		birth = yes
+	}
+
+	1225.1.1 = {
+		death = yes
+	}
+}
+
+93131 = {
+	name = "Muhammad Ay Temur"
+	dynasty = 7507
+	religion = shiite
+	culture = persian
+	father = 45101
+	1321.1.1 = {
+		birth = yes
+	}
+	1346.1.1 = {
+		death = yes
+	}
+}
+
+93132 = {
+	name = "Suri" # fictional
+	dynasty = 1059986
+	religion = buddhist
+	culture = persian
+	trait = mahayana_buddhist
+	trait = sympathy_islam
+	father = 248620 # Amir cannot really be father of Muhammed unless he lived to be over 100 years of age
+	920.1.1 = {
+		birth = yes
+	}
+	980.1.1 = {
+		death = yes
+	}
+}
+
+93133 = {
+	name = "Muhammad"
+	dynasty = 1059986
+	religion = buddhist
+	culture = persian
+	trait = mahayana_buddhist
+	trait = sympathy_islam
+	father = 93132
+	960.1.1 = {
+		birth = yes
+	}
+	1011.1.1 = {
+		death = yes
+	}
+}
+
+93134 = {
+	name = "Muhammad"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93133
+	980.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+93135 = {
+	name = "Shith"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93133
+	982.1.1 = {
+		birth = yes
+	}
+	1029.1.1 = {
+		death = yes
+	}
+}
+
+93136 = {
+	name = "Abbas"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93135
+	1000.1.1 = {
+		birth = yes
+	}
+	1059.1.1 = {
+		death = yes
+	}
+}
+
+93137 = {
+	name = "Muhammad"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93136
+	1030.1.1 = {
+		birth = yes
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+
+93138 = {
+	name = "Hasan"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93137
+	1050.1.1 = {
+		birth = yes
+	}
+	1100.1.1 = {
+		death = yes
+	}
+}
+
+93139 = {
+	name = "Hussain"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93138
+	1084.1.1 = {
+		birth = yes
+	}
+	1146.1.1 = {
+		death = yes
+	}
+}
+
+93140 = {
+	name = "Saif"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93139
+	1110.1.1 = {
+		birth = yes
+	}
+	1149.1.1 = {
+		death = yes
+	}
+}
+
+93141 = {
+	name = "Säm"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93139
+	1111.1.1 = {
+		birth = yes
+	}
+	1155.1.1 = {
+		death = yes
+	}
+}
+
+93143 = {
+	name = "Hussain"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93139
+	1112.1.1 = {
+		birth = yes
+	}
+	1161.1.1 = {
+		death = yes
+	}
+}
+
+93144 = {
+	name = "Säm"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 144143
+	1167.1.1 = {
+		birth = yes
+	}
+	1213.1.1 = {
+		death = yes
+	}
+}
+
+93145 = {
+	name = "Atsiz"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93143
+	1150.1.1 = {
+		birth = yes
+	}
+	1214.1.1 = {
+		death = yes
+	}
+}
+
+93146 = {
+	name = "Mas'ud"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93139
+	1115.1.1 = {
+		birth = yes
+	}
+	1163.1.1 = {
+		death = yes
+	}
+}
+
+93147 = {
+	name = "Muhammad"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93146
+	1140.1.1 = {
+		birth = yes
+	}
+	1192.1.1 = {
+		death = yes
+	}
+}
+
+93148 = {
+	name = "Säm"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93147
+	1160.1.1 = {
+		birth = yes
+	}
+	1206.1.1 = {
+		death = yes
+	}
+}
+
+93149 = {
+	name = "Jalal-ud-Din Ali"
+	dynasty = 791
+	religion = sunni
+	culture = persian
+	father = 93148
+	1180.1.1 = {
+		birth = yes
+	}
+	1215.1.1 = {
+		death = yes
+	}
+}
+
+93150 = {
+	name = "Marghini"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	1130.1.1 = {
+		birth = yes
+	}
+	1180.1.1 = {
+		death = yes
+	}
+}
+
+93151 = {
+	name = "Taju ud-Din Uthman"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93150
+	1160.1.1 = {
+		birth = yes
+	}
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+93152 = {
+	name = "Izz ud-Din Umar"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93150
+	1162.1.1 = {
+		birth = yes
+	}
+	1206.1.1 = {
+		death = yes
+	}
+}
+
+93153 = {
+	name = "Rukh ud-Din Abu-Bakr"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93151
+	1190.1.1 = {
+		birth = yes
+	}
+	1245.1.1 = {
+		death = yes
+	}
+}
+
+93154 = {
+	name = "Shams ud-Din"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93153
+	1210.1.1 = {
+		birth = yes
+	}
+	1277.1.1 = {
+		death = yes
+	}
+}
+
+93155 = {
+	name = "Shams ud-Din"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93154
+	1235.1.1 = {
+		birth = yes
+	}
+	1295.1.1 = {
+		death = yes
+	}
+}
+
+93156 = {
+	name = "Fakhr ud-Din"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93155
+	1255.1.1 = {
+		birth = yes
+	}
+	1308.1.1 = {
+		death = yes
+	}
+}
+
+93157 = {
+	name = "Shams ud-Din"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93156
+	1275.1.1 = {
+		birth = yes
+	}
+	1330.1.1 = {
+		death = yes
+	}
+}
+
+93158 = {
+	name = "Hafiz"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93157
+	1295.1.1 = {
+		birth = yes
+	}
+	1332.1.1 = {
+		death = yes
+	}
+}
+
+93159 = {
+	name = "Mu'izz ud-Din"
+	dynasty = 7330
+	religion = sunni
+	culture = persian
+	father = 93158
+	1315.1.1 = {
+		birth = yes
+	}
+	1370.1.1 = {
+		death = yes
+	}
+}
+
+93162 = {
+	name = "Qarin" # Karen II
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 41606
+	1080.1.1 = {
+		birth = yes
+	}
+	1117.1.1 = {
+		death = yes
+	}
+}
+93163 = {
+	name = "Rustam" # IV
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 41606
+	1082.1.1 = {
+		birth = yes
+	}
+	1118.1.1 = {
+		death = yes
+	}
+}
+93164 = {
+	name = "Ali"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93163
+	1102.1.1 = {
+		birth = yes
+	}
+	1142.1.1 = {
+		death = yes
+	}
+}
+
+93165 = {
+	name = "Ghazi Rustam"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93164
+	1120.1.1 = {
+		birth = yes
+	}
+	1165.1.1 = {
+		death = yes
+	}
+}
+
+93166 = {
+	name = "Hassan"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93165
+	1140.1.1 = {
+		birth = yes
+	}
+	1173.1.1 = {
+		death = yes
+	}
+}
+
+93167 = {
+	name = "Ardashir"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93166
+	1156.1.1 = {
+		birth = yes
+	}
+	1206.1.1 = {
+		death = yes
+	}
+}
+
+93168 = {
+	name = "Ghazi Rustam"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93167
+	1176.1.1 = {
+		birth = yes
+	}
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+93169 = {
+	name = "Ardashir"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93168
+	1192.1.1 = {
+		birth = yes
+	}
+	1249.1.1 = {
+		death = yes
+	}
+}
+
+93170 = {
+	name = "Muhammad"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93169
+	1220.1.1 = {
+		birth = yes
+	}
+	1267.1.1 = {
+		death = yes
+	}
+}
+93171 = {
+	name = "Ali"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93170
+	1240.1.1 = {
+		birth = yes
+	}
+	1271.1.1 = {
+		death = yes
+	}
+}
+
+93172 = {
+	name = "Yezdigerd"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93171
+	1258.1.1 = {
+		birth = yes
+	}
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+93173 = {
+	name = "Shariyar"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93172
+	1278.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+93174 = {
+	name = "Kai-Kushrau"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93173
+	1294.1.1 = {
+		birth = yes
+	}
+	1328.1.1 = {
+		death = yes
+	}
+}
+
+93175 = {
+	name = "Sharaf"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93173
+	1299.1.1 = {
+		birth = yes
+	}
+	1334.1.1 = {
+		death = yes
+	}
+}
+93176 = {
+	name = "Hassan"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 93173
+	1301.1.1 = {
+		birth = yes
+	}
+	1349.1.1 = {
+		death = yes
+	}
+}
+93177 = {
+	name = "Ardashir"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216915
+	1000.1.1 = {
+		birth = yes
+	}
+	1047.1.1 = {
+		death = yes
+	}
+}
+
+93178 = {
+	name = "Namwar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93177
+	trait = sympathy_zoroastrianism
+	1020.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		death = yes
+	}
+}
+
+93179 = {
+	name = "Sharaf"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93178
+	trait = sympathy_zoroastrianism
+	1040.1.1 = {
+		birth = yes
+	}
+	1109.1.1 = {
+		death = yes
+	}
+}
+
+93180 = {
+	name = "Shariwash"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93179
+	1093.1.1 = {
+		birth = yes
+	}
+	1168.1.1 = {
+		death = yes
+	}
+}
+
+93181 = {
+	name = "Kai-Ka'us"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93180
+	1115.1.1 = {
+		birth = yes
+	}
+	1184.1.1 = {
+		death = yes
+	}
+}
+
+93182 = {
+	name = "Hazarasp"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93181
+	1150.1.1 = {
+		birth = yes
+	}
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+93183 = {
+	name = "Zarin-Kemer"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93182
+	1170.1.1 = {
+		birth = yes
+	}
+	1213.1.1 = {
+		death = yes
+	}
+}
+
+93184 = {
+	name = "Bisutun"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93182
+	1175.1.1 = {
+		birth = yes
+	}
+	1223.1.1 = {
+		death = yes
+	}
+}
+
+93185 = {
+	name = "Namwar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93184
+	1195.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+93186 = {
+	name = "Ardashir"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93184
+	1200.1.1 = {
+		birth = yes
+	}
+	1236.1.1 = {
+		death = yes
+	}
+}
+
+93187 = {
+	name = "Rakim Gaubara"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93186
+	1220.1.1 = {
+		birth = yes
+	}
+	1272.1.1 = {
+		death = yes
+	}
+}
+
+93188 = {
+	name = "Namwar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93187
+	1240.1.1 = {
+		birth = yes
+	}
+	1302.1.1 = {
+		death = yes
+	}
+}
+
+93189 = {
+	name = "Kai-Khusrau"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93188
+	1260.1.1 = {
+		birth = yes
+	}
+	1312.1.1 = {
+		death = yes
+	}
+}
+
+93190 = {
+	name = "Muhammad"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93189
+	1280.1.1 = {
+		birth = yes
+	}
+	1318.1.1 = {
+		death = yes
+	}
+}
+
+93191 = {
+	name = "Shariyar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93190
+	1296.1.1 = {
+		birth = yes
+	}
+	1325.1.1 = {
+		death = yes
+	}
+}
+
+93192 = {
+	name = "Ziyar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93190
+	1298.1.1 = {
+		birth = yes
+	}
+	1334.1.1 = {
+		death = yes
+	}
+}
+
+93193 = {
+	name = "Iskandar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 93192
+	1318.1.1 = {
+		birth = yes
+	}
+	1360.1.1 = {
+		death = yes
+	}
+}
+
+93268 = {
+	name = "Sharaf ad-Din Muzzafar"
+	dynasty = 101915
+	religion = sunni
+	culture = persian
+	1270.1.1 = {
+		birth = yes
+	}
+	1314.1.1 = {
+		death = yes
+	}
+}
+
+93269 = {
+	name = "Tagh ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	1010.1.1 = {
+		birth = yes
+	}
+	1073.1.1 = {
+		death = yes
+	}
+}
+
+93270 = {
+	name = "Baha ud-Dawla Tahir"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93269
+	1030.1.1 = {
+		birth = yes
+	}
+	1088.1.1 = {
+		death = yes
+	}
+}
+93271 = {
+	name = "Badr ud-Dawla Abul Abbas"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93270
+	1050.1.1 = {
+		birth = yes
+	}
+	1090.1.1 = {
+		death = yes
+	}
+}
+93272 = {
+	name = "Baha ud-Dawla Khalaf"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93270
+	1053.1.1 = {
+		birth = yes
+	}
+	1103.1.1 = {
+		death = yes
+	}
+}
+
+93273 = {
+	name = "Tagh ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93272
+	1095.1.1 = {
+		birth = yes
+	}
+	1164.1.1 = {
+		death = yes
+	}
+}
+
+93274 = {
+	name = "Shams ad-Din Ahmad"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93273
+	1120.1.1 = {
+		birth = yes
+	}
+	1167.1.1 = {
+		death = yes
+	}
+}
+93275 = {
+	name = "Izz ad-Din Muhammad"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93274
+	1140.1.1 = {
+		birth = yes
+	}
+	1168.1.1 = {
+		death = yes
+	}
+}
+93276 = {
+	name = "Tagh ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93275
+	1160.1.1 = {
+		birth = yes
+	}
+	1215.1.1 = {
+		death = yes
+	}
+}
+
+93277 = {
+	name = "Yamin ad-Din Bahram"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93276
+	1180.1.1 = {
+		birth = yes
+	}
+	1221.1.1 = {
+		death = yes
+	}
+}
+
+93278 = {
+	name = "Tagh ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93277
+	1200.1.1 = {
+		birth = yes
+	}
+	1226.1.1 = {
+		death = yes
+	}
+}
+
+93279 = {
+	name = "Shihab ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93277
+	1201.1.1 = {
+		birth = yes
+	}
+	1226.1.1 = {
+		death = yes
+	}
+}
+
+93280 = {
+	name = "Rukh ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93277
+	1202.1.1 = {
+		birth = yes
+	}
+	1226.1.1 = {
+		death = yes
+	}
+}
+
+93281 = {
+	name = "Ala ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93277
+	1203.1.1 = {
+		birth = yes
+	}
+	1226.1.1 = {
+		death = yes
+	}
+}
+
+93282 = {
+	name = "Nasir ad-Din"
+	dynasty = 7338
+	religion = sunni
+	culture = persian
+	father = 93277
+	1204.1.1 = {
+		birth = yes
+	}
+	1226.1.1 = {
+		death = yes
+	}
+}
+
+93284 = {
+	name = "Mas'ud"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	1170.1.1 = {
+		birth = yes
+	}
+	1225.1.1 = {
+		death = yes
+	}
+}
+
+93285 = {
+	name = "Shams al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93284
+	1195.1.1 = {
+		birth = yes
+	}
+	1255.1.1 = {
+		death = yes
+	}
+}
+
+93286 = {
+	name = "Mubariz al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93284
+	1200.1.1 = {
+		birth = yes
+	}
+	1250.1.1 = {
+		death = yes
+	}
+}
+
+93287 = {
+	name = "Nasir al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93286
+	1238.1.1 = {
+		birth = yes
+	}
+	1318.1.1 = {
+		death = yes
+	}
+}
+
+93288 = {
+	name = "Nusrat al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93287
+	1268.1.1 = {
+		birth = yes
+	}
+	1331.1.1 = {
+		death = yes
+	}
+}
+
+93289 = {
+	name = "Rukh al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93287
+	1270.1.1 = {
+		birth = yes
+	}
+	1320.1.1 = {
+		death = yes
+	}
+}
+
+93290 = {
+	name = "Qutb al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93289
+	1290.1.1 = {
+		birth = yes
+	}
+	1346.1.1 = {
+		death = yes
+	}
+}
+
+93291 = {
+	name = "Taj al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93290
+	1310.1.1 = {
+		birth = yes
+	}
+	1351.1.1 = {
+		death = yes
+	}
+}
+
+93292 = {
+	name = "Jalal al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93289
+	1295.1.1 = {
+		birth = yes
+	}
+	1352.1.1 = {
+		death = yes
+	}
+}
+
+93293 = {
+	name = "Izz al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93289
+	1310.1.1 = {
+		birth = yes
+	}
+	1382.9.29 = {
+		death = yes
+	}
+}
+
+93294 = {
+	name = "Qutb al-Din"
+	dynasty = 7339
+	religion = sunni
+	culture = persian
+	father = 93293
+	1330.1.1 = {
+		birth = yes
+	}
+	1386.1.1 = {
+		death = yes
+	}
+}
+
+93295 = {
+	name = "Qutlugh Inanj"
+	dynasty = 101876
+	religion = sunni
+	culture = persian
+	father = 144052
+	1158.1.1 = {
+		birth = yes
+	}
+	1195.1.1 = {
+		death = yes
+	}
+}
+
+93296 = {
+	name = "Nusrat ud-Din Abu-Bakr"
+	dynasty = 101876
+	religion = sunni
+	culture = persian
+	father = 93295
+	1178.1.1 = {
+		birth = yes
+	}
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+93297 = {
+	name = "Muzaffar ud-Din Ozbeg"
+	dynasty = 101876
+	religion = sunni
+	culture = persian
+	father = 93295
+	1180.1.1 = {
+		birth = yes
+	}
+	1220.1.1 = {
+		death = yes
+	}
+}
+
+93298 = {
+	name = "Qizil Arslan"
+	dynasty = 101876
+	religion = sunni
+	culture = persian
+	father = 93295
+	1182.1.1 = {
+		birth = yes
+	}
+	1225.1.1 = {
+		death = yes
+	}
+}
+
+93299 = {
+	name = "Nusrat ud-Din"
+	dynasty = 101876
+	religion = sunni
+	culture = persian
+	father = 93295
+	1190.1.1 = {
+		birth = yes
+	}
+	1230.1.1 = {
+		death = yes
+	}
+}
+
+93300 = {
+	name = "Sayf ad-Din Is'Haq"
+	dynasty = 7340
+	religion = shiite
+	culture = persian
+	1252.1.1 = {
+		birth = yes
+	}
+	1304.1.1 = {
+		add_spouse = 93302
+	}
+	1334.1.1 = {
+		death = yes
+	}
+}
+
+93301 = {
+	name = "Taj al-Din Ebrahim"
+	#AKA Zahed Gilani
+	dynasty = 7341
+	religion = shiite
+	culture = persian
+	1216.1.1 = {
+		birth = yes
+	}
+	1301.1.1 = {
+		death = yes
+	}
+}
+
+93302 = {
+	name = "Bibi Fatemeh"
+	female = yes
+	dynasty = 7341
+	religion = shiite
+	culture = persian
+	father = 93301
+	1285.1.1 = {
+		birth = yes
+	}
+	1325.1.1 = {
+		death = yes
+	}
+}
+
+93303 = {
+	name = "Sadr al-Din Musa"
+	dynasty = 7340
+	religion = shiite
+	culture = persian
+	father = 93300
+	mother = 93302
+	1305.1.1 = {
+		birth = yes
+	}
+	1391.1.1 = {
+		death = yes
+	}
+}
+
+163099 = {
+	name = "Nasr"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 163154
+	830.1.1 = {
+		birth = yes
+	}
+
+	867.1.1 = {
+		effect = {
+			decadence = -25
+			spawn_unit = {
+				province = 902 # Dashhowuz
+				owner = ROOT
+				#leader = ROOT
+				troops = {
+					light_infantry = { 277 277 }
+					heavy_infantry = { 244 244 }
+					archers = { 122 122 }
+					light_cavalry = { 54 54 }
+				}
+				attrition = 1.0
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 23
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 902 # Dashhowuz
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 277 277 }
+						heavy_infantry = { 244 244 }
+						archers = { 122 122 }
+						light_cavalry = { 54 54 }
+					}
+					attrition = 1.0
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 27
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 902 # Dashhowuz
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 277 277 }
+						heavy_infantry = { 244 244 }
+						archers = { 122 122 }
+						light_cavalry = { 54 54 }
+					}
+					attrition = 1.0
+				}
+			}
+		}
+	}
+
+	892.1.1 = {
+		death = yes
+	}
+}
+
+163100 = {
+	name = "Muhammad"
+	dynasty = 811
+	religion = sunni
+	culture = persian
+	father = 163159
+	840.1.1 = {
+		birth = yes
+	}
+	873.1.1 = {
+		death = yes
+	}
+}
+
+163101 = {
+	name = "Ya'qub" # Founder of the Saffarid dynasty
+	dynasty = 812
+	martial = 8
+	religion = sunni
+	culture = persian
+	father = 163163
+	trait = brave
+	trait = wroth
+	trait = charitable
+	trait = ambitious
+	trait = brilliant_strategist
+	840.1.1 = {
+		birth = yes
+	}
+	867.1.1 = {
+		add_claim = d_kabul
+		add_claim = d_bhakkar
+		add_claim = d_sauvira
+		effect = {
+			decadence = -25
+			spawn_unit = {
+				province = 906 # Birjand
+				owner = ROOT
+				#leader = ROOT
+				troops = {
+					light_infantry = { 99 99 }
+					heavy_infantry = { 83 83 }
+					pikemen = { 20 20 }
+					archers = { 47 47 }
+					light_cavalry = { 37 37 }
+					knights = { 16 16 }
+					horse_archers = { 23 23 }
+				}
+				attrition = 1.0
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 23
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 906 # Birjand
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 99 99 }
+						heavy_infantry = { 83 83 }
+						pikemen = { 20 20 }
+						archers = { 47 47 }
+						light_cavalry = { 37 37 }
+						knights = { 16 16 }
+						horse_archers = { 23 23 }
+					}
+					attrition = 1.0
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 27
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 906 # Birjand
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 99 99 }
+						heavy_infantry = { 83 83 }
+						pikemen = { 20 20 }
+						archers = { 47 47 }
+						light_cavalry = { 37 37 }
+						knights = { 16 16 }
+						horse_archers = { 23 23 }
+					}
+					attrition = 1.0
+				}
+			}
+		}
+	}
+	879.6.5 = {
+		death = yes
+	}
+}
+
+74030 = {
+	name = "Dariush"
+	dynasty = 12273
+
+	culture = persian
+	religion = zoroastrian
+
+	835.1.1 = {
+		birth = yes
+	}
+	880.1.1 = {
+		death = yes
+	}
+}
+
+74033 = {
+	name = "Eskander"
+	dynasty = 12273
+
+	father = 74030
+
+	culture = persian
+	religion = zoroastrian
+
+	862.1.1 = {
+		birth = yes
+	}
+	928.1.1 = {
+		death = yes
+	}
+}
+
+159599 = {
+	name = "Sasan" # II
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	130.11.1 = {
+		birth = yes
+		create_bloodline = {
+			type = sassanid
+			has_dlc = "Holy Fury"
+		}
+	}
+	200.1.1 = {
+		death = yes
+	}
+}
+
+159600 = {
+	name = "Babak" # II
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 159599
+	150.11.1 = {
+		birth = yes
+	}
+	222.1.1 = {
+		death = yes
+	}
+}
+
+159601 = {
+	name = "Ardeshir" # I
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 159600
+	180.11.1 = {
+		birth = yes
+	}
+	241.1.1 = {
+		death = yes
+	}
+}
+
+159602 = {
+	name = "Shapur" # I
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 159601
+	215.11.1 = {
+		birth = yes
+	}
+	272.1.1 = {
+		death = yes
+	}
+}
+
+163153 = {
+	name = "Asad"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 188637
+	756.1.1 = {
+		birth = yes
+	}
+	825.1.1 = {
+		death = yes
+	}
+}
+
+163154 = {
+	name = "Ahmad"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 163153
+	790.1.1 = {
+		birth = yes
+	}
+	864.1.1 = {
+		death = yes
+	}
+}
+
+163155 = {
+	name = "Ilyas"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 163153
+	788.1.1 = {
+		birth = yes
+	}
+	856.1.1 = {
+		death = yes
+	}
+}
+
+163156 = {
+	name = "Ibrahim"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 163155
+	810.1.1 = {
+		birth = yes
+	}
+	868.1.1 = {
+		death = yes
+	}
+}
+
+163157 = {
+	name = "Isma'il"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 163154
+	820.1.1 = {
+		birth = yes
+	}
+	907.1.1 = {
+		death = yes
+	}
+}
+
+163158 = {
+	name = "Adballah"
+	dynasty = 811
+	religion = sunni
+	culture = persian
+	father = 188686
+	798.1.1 = {
+		birth = yes
+	}
+	845.1.1 = {
+		death = yes
+	}
+}
+
+163159 = {
+	name = "Tahir"
+	dynasty = 811
+	religion = sunni
+	culture = persian
+	father = 163158
+	815.1.1 = {
+		birth = yes
+	}
+	862.1.1 = {
+		death = yes
+	}
+}
+
+163160 = {
+	name = "Ubaudallah"
+	dynasty = 811
+	religion = sunni
+	culture = persian
+	father = 163158
+	822.1.1 = {
+		birth = yes
+	}
+	881.1.1 = {
+		death = yes
+	}
+}
+
+163161 = {
+	name = "Sulayman"
+	dynasty = 811
+	religion = sunni
+	culture = persian
+	father = 163158
+	824.1.1 = {
+		birth = yes
+	}
+	879.1.1 = {
+		death = yes
+	}
+}
+
+163162 = {
+	name = "Muhammad"
+	dynasty = 811
+	religion = sunni
+	culture = persian
+	father = 163158
+	820.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+163163 = {
+	name = "Layth"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	810.1.1 = {
+		birth = yes
+	}
+	860.1.1 = {
+		death = yes
+	}
+}
+
+163164 = {
+	name = "Amr"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 163163
+	841.1.1 = {
+		birth = yes
+	}
+	901.1.1 = {
+		death = yes
+	}
+}
+
+163165 = {
+	name = "Ali"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 163163
+	842.1.1 = {
+		birth = yes
+	}
+	882.1.1 = {
+		death = yes
+	}
+}
+
+180602 = {
+	name = "Sapur"
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 159600
+	177.1.1 = {
+		birth = yes
+	}
+	208.1.1 = {
+		death = yes
+	}
+}
+
+180603 = {
+	name = "Raidashir"
+	dynasty = 1029100
+	religion = manichean
+	culture = persian
+	father = 159600
+	182.1.1 = {
+		birth = yes
+	}
+	245.1.1 = {
+		death = yes
+	}
+}
+
+180605 = {
+	name = "Shapur"
+	# Shapur I, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 159601
+	215.1.1 = {
+		birth = yes
+	}
+	272.1.1 = {
+		death = yes
+	}
+}
+
+180606 = {
+	name = "Hormazd"
+	# Hormazd I, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180605
+	246.1.1 = {
+		birth = yes
+	}
+	273.1.1 = {
+		death = yes
+	}
+}
+
+180607 = {
+	name = "Bahram"
+	# Bahram I, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180605
+	240.1.1 = {
+		birth = yes
+	}
+	276.1.1 = {
+		death = yes
+	}
+}
+
+180608 = {
+	name = "Bahram"
+	# Bahram II, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180607
+	260.1.1 = {
+		birth = yes
+	}
+	293.1.1 = {
+		death = yes
+	}
+}
+
+180609 = {
+	name = "Bahram"
+	# Bahram III, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180608
+	285.1.1 = {
+		birth = yes
+	}
+	293.4.1 = {
+		death = yes
+	}
+}
+
+180610 = {
+	name = "Narseh"
+	# Narseh, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180605
+	244.1.1 = {
+		birth = yes
+	}
+	305.1.1 = {
+		death = yes
+	}
+}
+
+180611 = {
+	name = "Hormazd"
+	# Hormazd II, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180610
+	268.1.1 = {
+		birth = yes
+	}
+	309.1.1 = {
+		death = yes
+	}
+}
+
+180612 = {
+	name = "Hormazd"
+	dynasty = 1029100
+	religion = orthodox
+	culture = persian
+	father = 180611
+	299.1.1 = {
+		birth = yes
+	}
+	368.1.1 = {
+		death = yes
+	}
+}
+
+180613 = {
+	name = "Hormazd"
+	# Byzantine proconsul
+	dynasty = 1029100
+	religion = orthodox
+	culture = greek
+	father = 180612
+	325.1.1 = {
+		birth = yes
+	}
+	375.1.1 = {
+		death = yes
+	}
+}
+
+180614 = {
+	name = "Ardeshir"
+	# Ardeshir II, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180611
+	307.1.1 = {
+		birth = yes
+	}
+	383.1.1 = {
+		death = yes
+	}
+}
+
+180615 = {
+	name = "Zruanduxt"
+	# wife of Khosrov IV of Armenia
+	female = yes
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180614
+	330.1.1 = {
+		birth = yes
+	}
+	380.1.1 = {
+		death = yes
+	}
+}
+
+180616 = {
+	name = "Shapur"
+	# Shapur III, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180614
+	333.1.1 = {
+		birth = yes
+	}
+	388.1.1 = {
+		death = yes
+	}
+}
+
+180617 = {
+	name = "Shapur"
+	# Shapur II, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180611
+	309.1.1 = {
+		birth = yes
+	}
+	379.1.1 = {
+		death = yes
+	}
+}
+
+180618 = {
+	name = "Bahram"
+	# Bahram IV, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180617
+	339.1.1 = {
+		birth = yes
+	}
+	399.1.1 = {
+		death = yes
+	}
+}
+
+180619 = {
+	name = "Yazdegerd"
+	# Yazdegerd I, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180616
+	369.1.1 = {
+		birth = yes
+	}
+	421.1.1 = {
+		death = yes
+	}
+}
+
+180620 = {
+	name = "Bahram"
+	# Bahram V, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180619
+	393.1.1 = {
+		birth = yes
+	}
+	438.1.1 = {
+		death = yes
+	}
+}
+
+180621 = {
+	name = "Yazdegerd"
+	# Yazdegerd II, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180620
+	417.1.1 = {
+		birth = yes
+	}
+	457.1.1 = {
+		death = yes
+	}
+}
+
+180622 = {
+	name = "Hormazd"
+	# Hormazd III, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180621
+	436.1.1 = {
+		birth = yes
+	}
+	459.1.1 = {
+		death = yes
+	}
+}
+
+180623 = {
+	name = "Balash"
+	# Balash, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180621
+	440.1.1 = {
+		birth = yes
+	}
+	488.1.1 = {
+		death = yes
+	}
+}
+
+180624 = {
+	name = "Peroz"
+	# Peroz I, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180621
+	438.1.1 = {
+		birth = yes
+	}
+	484.6.1 = {
+		death = yes
+	}
+}
+
+180625 = {
+	name = "Djamasp"
+	# Djamasp, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180624
+	470.1.1 = {
+		birth = yes
+	}
+	535.1.1 = {
+		death = yes
+	}
+}
+
+180626 = {
+	name = "Zareh"
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180624
+	466.1.1 = {
+		birth = yes
+	}
+	485.1.1 = {
+		death = yes
+	}
+}
+
+180627 = {
+	name = "Kavadh"
+	# Kavadh I, Emperor of Persia
+	dynasty = 1029100
+	religion = mazdaki
+	culture = persian
+	father = 180624
+	469.1.1 = {
+		birth = yes
+	}
+	531.9.1 = {
+		death = yes
+	}
+}
+
+180628 = {
+	name = "Khosrau"
+	# Khosrau I, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180627
+	505.1.1 = {
+		birth = yes
+	}
+	579.1.1 = {
+		death = yes
+	}
+}
+
+180629 = {
+	name = "Bistam"
+	# pretender to throne of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180628
+	532.1.1 = {
+		birth = yes
+	}
+	596.1.1 = {
+		death = yes
+	}
+}
+
+180630 = {
+	name = "Hormazd"
+	# Hormazd IV, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180628
+	528.1.1 = {
+		birth = yes
+	}
+	590.1.1 = {
+		death = yes
+	}
+}
+
+180631 = {
+	name = "Khosrau"
+	# Khosrau II, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180630
+	560.1.1 = {
+		birth = yes
+	}
+	589.1.1 = {
+		add_spouse = 180646
+	}
+	628.2.28 = {
+		death = yes
+	}
+}
+
+180632 = {
+	name = "Kavadh"
+	# Kavadh II, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180631
+	590.1.1 = {
+		birth = yes
+	}
+	628.6.1 = {
+		death = yes
+	}
+}
+
+180633 = {
+	name = "Ardeshir"
+	# Ardeshir III, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180632
+	621.1.1 = {
+		birth = yes
+	}
+	630.4.27 = {
+		death = yes
+	}
+}
+
+180634 = {
+	name = "Purandokht"
+	# Purandokht, Empress of Persia
+	female = yes
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180631
+	592.1.1 = {
+		birth = yes
+	}
+	631.5.1 = {
+		death = yes
+	}
+}
+
+180635 = {
+	name = "Azarmidokht"
+	# Azarmidokht, Empress of Persia
+	female = yes
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180631
+	593.1.1 = {
+		birth = yes
+	}
+	631.9.1 = {
+		death = yes
+	}
+}
+
+180636 = {
+	name = "Shahryar"
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180631
+	mother = 180646
+	595.1.1 = {
+		birth = yes
+	}
+	628.5.1 = {
+		death = yes
+	}
+}
+
+180637 = {
+	name = "Yazdegerd"
+	# Yazdegerd III, Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180636
+	617.1.1 = {
+		birth = yes
+	}
+	651.1.1 = {
+		death = yes
+	}
+}
+
+180638 = {
+	name = "Shahrbanu"
+	# possible wife of Husayn ibn Ali
+	female = yes
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180637
+	643.1.1 = {
+		birth = yes
+	}
+	700.1.1 = {
+		death = yes
+	}
+}
+
+180639 = {
+	name = "Izdunand"
+	# wife of Bustanai ben Haninai
+	female = yes
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180637
+	648.1.1 = {
+		birth = yes
+	}
+	700.1.1 = {
+		death = yes
+	}
+}
+
+180640 = {
+	name = "Peroz"
+	# Peroz II, would-be Emperor of Persia
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180637
+	645.1.1 = {
+		birth = yes
+	}
+	710.1.1 = {
+		death = yes
+	}
+}
+
+180641 = {
+	name = "Narsieh"
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180640
+	675.1.1 = {
+		birth = yes
+	}
+	730.1.1 = {
+		death = yes
+	}
+}
+
+180645 = {
+	name = "Bahram"
+	# Bahram VI, Emperor of Persia
+	dynasty = 1042070
+	religion = zoroastrian
+	culture = persian
+	553.1.1 = {
+		birth = yes
+		create_bloodline = {
+			type = parthian
+			has_dlc = "Holy Fury"
+		}
+	}
+	592.1.1 = {
+		death = yes
+	}
+}
+
+183243 = {
+	name = "Golshan"
+	female = yes
+
+	religion = zoroastrian
+	culture = persian
+	847.1.1 = {
+		birth = yes
+	}
+	915.1.1 = {
+		death = yes
+	}
+}
+
+188242 = {
+	name = "Jajjapa"
+	dynasty = 1042083 # Hunas
+	religion = hindu
+	culture = saka
+	trait = shaivist_hindu
+	trait = kshatriya
+	father = 191922
+	825.1.1 = {
+		birth = yes
+	}
+	880.1.1 = {
+		death = yes
+	}
+}
+
+188580 = {
+	name = "Afrig"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	280.9.4 = {
+		birth = yes
+	}
+	350.1.1 = {
+		death = yes
+	}
+}
+
+188581 = {
+	name = "Bagra"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188580
+	312.1.28 = {
+		birth = yes
+	}
+	380.1.1 = {
+		death = yes
+	}
+}
+
+188582 = {
+	name = "Sahhasak"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188581
+	337.1.1 = {
+		birth = yes
+	}
+	410.1.1 = {
+		death = yes
+	}
+}
+
+188583 = {
+	name = "Askajamuk"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188582
+	365.1.1 = {
+		birth = yes
+	}
+	440.1.1 = {
+		death = yes
+	}
+}
+
+188584 = {
+	name = "Azkajwar"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188583
+	400.1.1 = {
+		birth = yes
+	}
+	470.1.1 = {
+		death = yes
+	}
+}
+
+188585 = {
+	name = "Sahr"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188584
+	430.1.1 = {
+		birth = yes
+	}
+	500.1.1 = {
+		death = yes
+	}
+}
+
+188586 = {
+	name = "Shaush"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188585
+	460.1.1 = {
+		birth = yes
+	}
+	530.1.1 = {
+		death = yes
+	}
+}
+
+188587 = {
+	name = "Hamgari"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188586
+	490.1.1 = {
+		birth = yes
+	}
+	560.1.1 = {
+		death = yes
+	}
+}
+
+188588 = {
+	name = "Buzgar"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188587
+	520.1.1 = {
+		birth = yes
+	}
+	600.1.1 = {
+		death = yes
+	}
+}
+
+188589 = {
+	name = "Arsamuh"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188588
+	560.1.1 = {
+		birth = yes
+	}
+	625.1.1 = {
+		death = yes
+	}
+}
+
+188590 = {
+	name = "Sahr"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188589
+	600.1.1 = {
+		birth = yes
+	}
+	665.1.1 = {
+		death = yes
+	}
+}
+
+188591 = {
+	name = "Sabri"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188590
+	635.1.1 = {
+		birth = yes
+	}
+	690.1.1 = {
+		death = yes
+	}
+}
+
+188592 = {
+	name = "Azkajwar"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188591
+	665.1.1 = {
+		birth = yes
+	}
+	712.1.1 = {
+		death = yes
+	}
+}
+
+188593 = {
+	name = "Askajamuk"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188592
+	690.1.1 = {
+		birth = yes
+	}
+	740.1.1 = {
+		death = yes
+	}
+}
+
+188594 = {
+	name = "Sawashfan"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188593
+	715.1.1 = {
+		birth = yes
+	}
+	765.1.1 = {
+		death = yes
+	}
+}
+
+188595 = {
+	name = "Torkasbatha"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188594
+	740.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+188596 = {
+	name = "Abdallah"
+	dynasty = 1042112 # Afrighid
+	religion = zoroastrian
+	culture = persian
+	father = 188595
+	765.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		religion = sunni
+	}
+	815.1.1 = {
+		death = yes
+	}
+}
+
+188597 = {
+	name = "Mansur"
+	dynasty = 1042112 # Afrighid
+	religion = sunni
+	culture = persian
+	father = 188596
+	795.1.1 = {
+		birth = yes
+	}
+	850.1.1 = {
+		death = yes
+	}
+}
+
+188598 = {
+	name = "Eraq"
+	dynasty = 1042112 # Afrighid
+	religion = sunni
+	culture = persian
+	father = 188597
+	825.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		death = yes
+	}
+}
+
+188599 = {
+	name = "Muhammad"
+	dynasty = 1042112 # Afrighid
+	religion = sunni
+	culture = persian
+	father = 188598
+	865.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+188600 = {
+	name = "Abu Sa'id"
+	dynasty = 1042112 # Afrighid
+	religion = sunni
+	culture = persian
+	father = 188599
+	900.1.1 = {
+		birth = yes
+	}
+	970.1.1 = {
+		death = yes
+	}
+}
+
+188601 = {
+	name = "Abu Abdallah"
+	dynasty = 1042112 # Afrighid
+	religion = sunni
+	culture = persian
+	father = 188600
+	925.1.1 = {
+		birth = yes
+	}
+	995.1.1 = {
+		death = yes
+	}
+}
+
+188629 = {
+	name = "Khuzaymah"
+	dynasty = 1042122 # Banu Tamim
+	religion = sunni
+	culture = persian
+	695.1.1 = {
+		birth = yes
+	}
+	750.1.1 = {
+		death = yes
+	}
+}
+
+188630 = {
+	# Important Abbasid revolutionary, governor of Khorasan at times
+	name = "Khazim"
+	dynasty = 1042122 # Banu Tamim
+	religion = sunni
+	culture = persian
+	father = 188629
+	trait = brilliant_strategist
+	720.1.1 = {
+		birth = yes
+	}
+	771.1.1 = {
+		death = yes
+	}
+}
+
+188631 = {
+	name = "Khuzaymah"  # or Kuzayma
+	dynasty = 1042122 # Banu Tamim
+	religion = sunni
+	culture = persian
+	father = 188630
+	trait = skilled_tactician
+	742.1.1 = {
+		birth = yes
+	}
+	819.1.1 = {
+		death = yes
+	}
+}
+
+188664 = {
+	name = "Hezarhesp" # fictitious holder of Hormuz
+	dynasty = 1042138
+	religion = zoroastrian
+	culture = persian
+	748.1.1 = {
+		birth = yes
+	}
+	810.1.1 = {
+		death = yes
+	}
+}
+
+188660 = {
+	name = "al-Hudayn" # Kharijite rebel in Sistan
+	dynasty = 1042132 # of Uq
+	religion = ibadi
+	culture = persian
+	726.1.1 = {
+		birth = yes
+	}
+	793.1.1 = {
+		death = yes
+	}
+}
+
+188632 = {
+	name = "Abu-Khalid"
+	dynasty = 1042123 # Marwarrudhid
+	religion = sunni
+	culture = persian
+	725.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+188633 = {
+	name = "Muhammad"
+	dynasty = 1042123 # Marwarrudhid
+	religion = sunni
+	culture = persian
+	father = 188632
+	756.1.1 = {
+		birth = yes
+	}
+	820.1.1 = {
+		death = yes
+	}
+}
+
+188650 = {
+	name = "Abd al-Malik"  # Abu Awn Abd al-Malik ibn Yazid
+	dynasty = 1042126 # Azdid
+	religion = sunni
+	culture = persian
+	trait = brilliant_strategist
+	723.1.1 = {
+		birth = yes
+	}
+	785.1.1 = {
+		death = yes
+	}
+}
+
+188686 = {
+	name = "Tahir"
+	dynasty = 811 # Tahirid
+	religion = sunni
+	culture = persian
+	father = 188687
+	775.1.1 = {
+		birth = yes
+	}
+	822.1.1 = {
+		death = yes
+	}
+}
+
+188687 = {
+	name = "Husayn"
+	dynasty = 811 # Tahirid
+	religion = sunni
+	culture = persian
+	father = 188688
+	745.1.1 = {
+		birth = yes
+	}
+	806.1.1 = {
+		death = yes
+	}
+}
+
+188688 = {
+	name = "Ruzaiq"
+	dynasty = 811 # Tahirid
+	religion = zoroastrian
+	culture = persian
+	720.1.1 = {
+		birth = yes
+	}
+	745.1.1 = {
+		religion = sunni
+	}
+	782.1.1 = {
+		death = yes
+	}
+}
+
+188689 = {
+	name = "Talha"
+	dynasty = 811 # Tahirid
+	religion = sunni
+	culture = persian
+	father = 188686
+	797.1.1 = {
+		birth = yes
+	}
+	828.1.1 = {
+		death = yes
+	}
+}
+
+188695 = {
+	name = "Abu al-Najm" # general that fought Ustadhsis
+	dynasty = 1042154 # Sijistanid
+	religion = sunni
+	culture = persian
+	738.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+232753 = {
+	name = "Manuchehr"
+	dynasty = 101873
+	martial = 4
+	diplomacy = 4
+	intrigue = 4
+	stewardship = 4
+	religion = sunni
+	culture = persian
+	trait = gluttonous
+	trait = just
+	trait = tough_soldier
+	father = 144567
+	1099.1.1 = {
+		birth = yes
+	}
+	1116.1.1 = {
+		add_spouse = 232750
+	}
+	1160.1.1 = {
+		death = yes
+	}
+}
+
+188642 = {
+	name = "Barmak"
+	dynasty = 1042125 # Barmakid
+	religion = buddhist
+	culture = persian
+	670.1.1 = {
+		birth = yes
+	}
+	730.1.1 = {
+		religion = sunni
+	}
+	740.1.1 = {
+		death = yes
+	}
+}
+
+188643 = {
+	name = "Khalid"
+	dynasty = 1042125 # Barmakid
+	religion = buddhist
+	culture = persian
+	father = 188642
+	705.1.1 = {
+		birth = yes
+	}
+	730.1.1 = {
+		religion = sunni
+	}
+	782.1.1 = {
+		death = yes
+	}
+}
+
+188644 = {
+	name = "Yahya"
+	dynasty = 1042125 # Barmakid
+	religion = sunni
+	culture = persian
+	father = 188643
+	740.1.1 = {
+		birth = yes
+	}
+	806.1.1 = {
+		death = yes
+	}
+}
+
+188645 = {
+	name = "Fadl"
+	dynasty = 1042125 # Barmakid
+	religion = sunni
+	culture = persian
+	father = 188644
+	766.2.1 = {
+		birth = yes
+	}
+	808.11.1 = {
+		death = yes
+	}
+}
+
+188646 = {
+	name = "Jafar"
+	dynasty = 1042125 # Barmakid
+	religion = sunni
+	culture = persian
+	father = 188644
+	767.1.1 = {
+		birth = yes
+	}
+	803.1.1 = {
+		death = yes
+	}
+}
+
+188647 = {
+	name = "Musa"
+	dynasty = 1042125 # Barmakid
+	religion = sunni
+	culture = persian
+	father = 188644
+	768.1.1 = {
+		birth = yes
+	}
+	810.1.1 = {
+		death = yes
+	}
+}
+
+188651 = {
+	name = "Abdallah"
+	dynasty = 1042122 # Banu Tamim
+	religion = sunni
+	culture = persian
+	father = 188630
+	trait = skilled_tactician
+	750.1.1 = {
+		birth = yes
+	}
+	820.1.1 = {
+		death = yes
+	}
+}
+
+188652 = {
+	name = "Ibrahim"
+	dynasty = 1042122 # Banu Tamim
+	religion = sunni
+	culture = persian
+	father = 188630
+	trait = skilled_tactician
+	754.1.1 = {
+		birth = yes
+	}
+	825.1.1 = {
+		death = yes
+	}
+}
+
+146042 = {
+	name = "Sharaf"
+	dynasty = 1022361 # Al-Marwazi or Marwazid
+	religion = sunni
+	culture = persian
+
+	731.1.1 = {
+		birth = yes
+	}
+	788.1.1 = {
+		death = yes
+	}
+}
+
+146043 = {
+	name = "Muhammad"
+	dynasty = 1022361
+	religion = sunni
+	culture = persian
+	father = 146042
+	750.1.1 = {
+		birth = yes
+	}
+	817.1.1 = {
+		death = yes
+	}
+}
+
+146044 = {
+	name = "Abu Sa'id"
+	dynasty = 1022361
+	religion = sunni
+	culture = persian
+	father = 146043
+	800.1.1 = {
+		birth = yes
+	}
+	851.1.1 = {
+		death = yes
+	}
+}
+
+146045 = {
+	name = "Yusuf"
+	dynasty = 1022361
+	religion = sunni
+	culture = persian
+	father = 146044
+	820.1.1 = {
+		birth = yes
+	}
+	852.3.1 = {
+		death = yes
+	}
+}
+
+146093 = {
+	name = "Yazid"
+	dynasty = 1029124 # Yazidid
+	religion = sunni
+	culture = persian
+	father = 146090
+	962.1.1 = {
+		birth = yes
+	}
+	991.6.1 = {
+		dynasty = 101873
+	}
+	1027.11.1 = {
+		death = yes
+	}
+}
+
+146094 = {
+	name = "Manuchehr"
+	dynasty = 1029124
+	religion = sunni
+	culture = persian
+	father = 146093
+	976.1.1 = {
+		birth = yes
+	}
+	991.6.1 = {
+		dynasty = 101873
+	}
+	1034.1.1 = {
+		death = yes
+	}
+}
+
+146095 = {
+	name = "Hormuzd"
+	dynasty = 101873 # Kesranid or Kasranid
+	religion = sunni
+	culture = persian
+	father = 146094
+	1010.1.1 = {
+		birth = yes
+	}
+	1065.4.9 = {
+		death = yes
+	}
+}
+
+146096 = {
+	name = "Anushirvan"
+	dynasty = 1029124
+	religion = sunni
+	culture = persian
+	father = 146093
+	978.1.1 = {
+		birth = yes
+	}
+	991.6.1 = {
+		dynasty = 101873
+	}
+	999.1.1 = {
+		death = yes
+	}
+}
+
+146097 = {
+	name = "Ali"
+	dynasty = 1029124
+	religion = sunni
+	culture = persian
+	father = 146093
+	984.1.1 = {
+		birth = yes
+	}
+	991.6.1 = {
+		dynasty = 101873
+	}
+	1043.1.1 = {
+		death = yes
+	}
+}
+
+146098 = {
+	name = "Kubad"
+	dynasty = 1029124
+	religion = sunni
+	culture = persian
+	father = 146093
+	990.1.1 = {
+		birth = yes
+	}
+	991.6.1 = {
+		dynasty = 101873
+	}
+	1049.7.28 = {
+		death = yes
+	}
+}
+
+146099 = {
+	name = "Ahmad"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146093
+	996.1.1 = {
+		birth = yes
+	}
+	1044.1.1 = {
+		death = yes
+	}
+}
+
+146100 = {
+	name = "Ali"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146099
+	1016.1.1 = {
+		birth = yes
+	}
+	1050.3.1 = {
+		death = yes
+	}
+}
+
+146101 = {
+	name = "Salar"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146093
+	1002.1.1 = {
+		birth = yes
+	}
+	1063.2.20 = {
+		death = yes
+	}
+}
+
+146102 = {
+	name = "Shamkuyya"
+	dynasty = 101873
+	female = yes
+	religion = sunni
+	culture = persian
+	father = 146093
+	1008.1.1 = {
+		birth = yes
+	}
+	1065.1.1 = {
+		death = yes
+	}
+}
+
+146103 = {
+	name = "Mamlan"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146093
+	1014.1.1 = {
+		birth = yes
+	}
+	1067.2.24 = {
+		death = yes
+	}
+}
+
+146104 = {
+	name = "Manuchehr"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 20734
+	1050.1.1 = {
+		birth = yes
+	}
+	1106.1.1 = {
+		death = yes
+	}
+}
+
+146105 = {
+	name = "Afridun"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 232753
+	mother = 232750
+	1134.1.1 = {
+		birth = yes
+	}
+	1160.6.1 = {
+		death = yes
+	}
+}
+
+146106 = {
+	name = "Alchichek"
+	dynasty = 101873
+	female = yes
+	religion = sunni
+	culture = persian
+	father = 232753
+	mother = 232750
+	1130.1.1 = {
+		birth = yes
+	}
+	1137.1.1 = {
+		death = yes
+	}
+}
+
+146107 = {
+	name = "Fariburz"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 232753
+	mother = 232750
+	1136.1.1 = {
+		birth = yes
+	}
+	1138.1.1 = {
+		death = yes
+	}
+}
+
+146108 = {
+	name = "Abul Fath"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144568
+	1162.1.1 = {
+		birth = yes
+	}
+	1176.1.1 = {
+		death = yes
+	}
+}
+
+146109 = {
+	name = "Furuzan"
+	dynasty = 101873
+	female = yes
+	religion = sunni
+	culture = persian
+	father = 144568
+	1174.1.1 = {
+		birth = yes
+	}
+	1192.1.1 = {
+		death = yes
+	}
+}
+
+146110 = {
+	name = "Manuchehr"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144568
+	1176.1.1 = {
+		birth = yes
+	}
+	1192.1.1 = {
+		death = yes
+	}
+}
+
+146111 = {
+	name = "Arghavan"
+	dynasty = 101873
+	female = yes
+	religion = sunni
+	culture = persian
+	father = 144568
+	1178.1.1 = {
+		birth = yes
+	}
+	1192.1.1 = {
+		death = yes
+	}
+}
+
+146112 = {
+	name = "Nazgol"
+	dynasty = 101873
+	female = yes
+	religion = sunni
+	culture = persian
+	father = 144568
+	1180.1.1 = {
+		birth = yes
+	}
+	1192.1.1 = {
+		death = yes
+	}
+}
+
+146113 = {
+	name = "Shahanshah"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 232753
+	mother = 232750
+	1132.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+146114 = {
+	name = "Fariburz"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146105
+	1152.1.1 = {
+		birth = yes
+	}
+	1204.1.1 = {
+		death = yes
+	}
+}
+
+146115 = {
+	name = "Rashid"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144569
+	1173.1.1 = {
+		birth = yes
+	}
+	1222.1.1 = {
+		death = yes
+	}
+}
+
+146116 = {
+	name = "Jalaladdin"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144570
+	1194.1.1 = {
+		birth = yes
+	}
+	1255.1.1 = {
+		death = yes
+	}
+}
+
+146117 = {
+	name = "Afridun"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144571
+	1212.1.1 = {
+		birth = yes
+	}
+	1256.1.1 = {
+		death = yes
+	}
+}
+
+146118 = {
+	name = "Akhsitan"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144573
+	1258.1.1 = {
+		birth = yes
+	}
+	1294.1.1 = {
+		death = yes
+	}
+}
+
+146119 = {
+	name = "Siamerk"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146118
+	1273.1.1 = {
+		birth = yes
+	}
+	1290.1.1 = {
+		death = yes
+	}
+}
+
+146120 = {
+	name = "Keykavus"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146118
+	1275.1.1 = {
+		birth = yes
+	}
+	1317.1.1 = {
+		death = yes
+	}
+}
+
+146121 = {
+	name = "Kavus"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144574
+	1307.1.1 = {
+		birth = yes
+	}
+	1372.1.1 = {
+		death = yes
+	}
+}
+
+146122 = {
+	name = "Muhammad"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 144574
+	1309.1.1 = {
+		birth = yes
+	}
+	1367.1.1 = {
+		death = yes
+	}
+}
+
+146123 = {
+	name = "Noder"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146121
+	1325.1.1 = {
+		birth = yes
+	}
+	1370.1.1 = {
+		death = yes
+	}
+}
+
+146124 = {
+	name = "Hushang"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146121
+	1327.1.1 = {
+		birth = yes
+	}
+	1382.1.1 = {
+		death = yes
+	}
+}
+
+146125 = {
+	name = "Ibrahim"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	father = 146122
+	1351.1.1 = {
+		birth = yes
+	}
+	1417.9.15 = {
+		death = yes
+	}
+}
+
+146128 = {
+	name = "Guzdaham"
+	dynasty = 101873
+	religion = sunni
+	culture = persian
+	trait = ambitious
+	trait = deceitful
+	father = 146101
+	1033.1.1 = {
+		birth = yes
+	}
+	1072.1.1 = {
+		death = yes
+	}
+}
+
+188634 = {
+	name = "Noshrad"
+	dynasty = 1042070 # Samanid
+	religion = zoroastrian
+	culture = persian
+	father = 180645
+	590.1.1 = {
+		birth = yes
+	}
+	650.1.1 = {
+		death = yes
+	}
+}
+
+188635 = {
+	name = "Togmath"
+	dynasty = 1042070 # Samanid
+	religion = zoroastrian
+	culture = persian
+	father = 188634
+	635.1.1 = {
+		birth = yes
+	}
+	690.1.1 = {
+		death = yes
+	}
+}
+
+188636 = {
+	name = "Jotman"
+	dynasty = 1042070 # Samanid
+	religion = zoroastrian
+	culture = persian
+	father = 188635
+	680.1.1 = {
+		birth = yes
+	}
+	740.1.1 = {
+		death = yes
+	}
+}
+
+188637 = {
+	name = "Saman-Khuda"
+	dynasty = 810 # Samanid
+	religion = zoroastrian
+	culture = persian
+	father = 188636
+	720.1.1 = {
+		birth = yes
+	}
+	737.1.1 = {
+		religion = sunni
+	}
+	785.1.1 = {
+		death = yes
+	}
+}
+
+188638 = {
+	name = "Nuh"
+	dynasty = 810 # Samanid
+	religion = sunni
+	culture = persian
+	father = 163153
+	785.1.1 = {
+		birth = yes
+	}
+	841.1.1 = {
+		death = yes
+	}
+}
+
+188639 = {
+	name = "Yahya"
+	dynasty = 810 # Samanid
+	religion = sunni
+	culture = persian
+	father = 163153
+	792.1.1 = {
+		birth = yes
+	}
+	855.1.1 = {
+		death = yes
+	}
+}
+
+188666 = {
+	name = "Kamran" # fictitious count of Khozistan
+	dynasty = 1042141
+	religion = mazdaki
+	culture = persian
+	740.1.1 = {
+		birth = yes
+	}
+	785.1.1 = {
+		death = yes
+	}
+}
+
+188676 = {
+	name = "Yazdegerd" # fictitious holder of Sirjan
+	dynasty = 1042143
+	religion = zoroastrian
+	culture = persian
+	748.1.1 = {
+		birth = yes
+	}
+	808.1.1 = {
+		death = yes
+	}
+}
+
+188677 = {
+	name = "Manuchihr" # fictitious holder of Ladistan
+	dynasty = 1042144
+	religion = zoroastrian
+	culture = persian
+	735.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+188678 = {
+	name = "Gholam" # fictitious holder of Shiraz
+	dynasty = 1042145
+	religion = zoroastrian
+	culture = persian
+	730.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+191920 = {
+	name = "Toramana"	#Fictional predecessors of Jajjapa of Hunamandala
+	dynasty = 1042083 # Hunas
+	religion = hindu
+	culture = saka
+	trait = shaivist_hindu
+	trait = kshatriya
+	740.1.1 = {
+		birth = yes
+	}
+	780.1.1 = {
+		death = yes
+	}
+}
+
+191922 = {
+	name = "Mihirakula"	#Fictional predecessors of Jajjapa of Hunamandala
+	dynasty = 1042083 # Hunas
+	religion = hindu
+	culture = saka
+	trait = shaivist_hindu
+	trait = kshatriya
+	father = 191920
+	768.1.1 = {
+		birth = yes
+	}
+	840.1.1 = {
+		death = yes
+	}
+}
+
+191923 = {
+	name = "Jajjapa"	#II Fictional successor of Jajjapa of Hunamandala
+	dynasty = 1042083 # Hunas
+	religion = hindu
+	culture = saka
+	trait = shaivist_hindu
+	trait = kshatriya
+	father = 188242
+	860.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+188727 = {
+	name = "Salman" # fictitious holder of Luristan
+	dynasty = 1042160
+	religion = sunni
+	culture = persian
+	729.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+188728 = {
+	name = "Jahandar" # fictitious holder of Qwivir
+	dynasty = 1042161
+	religion = zoroastrian
+	culture = persian
+	738.1.1 = {
+		birth = yes
+	}
+	795.1.1 = {
+		death = yes
+	}
+}
+
+188729 = {
+	name = "Anushirvan" # fictitious holder of Esfahan
+	dynasty = 1042162
+	religion = mazdaki
+	culture = persian
+	732.1.1 = {
+		birth = yes
+	}
+	790.1.1 = {
+		death = yes
+	}
+}
+
+188730 = {
+	name = "Jahanshah" # fictitious holder of Yazd
+	dynasty = 1042163
+	religion = zoroastrian
+	culture = persian
+	741.1.1 = {
+		birth = yes
+	}
+	798.1.1 = {
+		death = yes
+	}
+}
+
+160283 = {
+	name = "Kawus"
+	dynasty = 1029100 #Sassanid
+	martial = 5
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 6
+	religion = mazdaki
+	culture = persian
+	father = 180627
+	504.1.1 = {
+		birth = yes
+	}
+	571.9.1 = {
+		death = yes
+	}
+}
+
+160284 = {
+	name = "Kavadh"  # name made up
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160283
+	545.1.1 = {
+		birth = yes
+	}
+	600.1.1 = {
+		death = yes
+	}
+}
+
+160285 = {
+	name = "Bav"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160284
+	590.1.1 = {
+		birth = yes
+	}
+	665.1.1 = {
+		death = yes
+	}
+}
+
+160288 = {
+	name = "Sorkhab"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160285 # debatable
+	635.1.1 = {
+		birth = yes
+	}
+	717.1.1 = {
+		death = yes
+	}
+}
+
+160289 = {
+	name = "Mehr Mardan"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160288
+	670.1.1 = {
+		birth = yes
+	}
+	755.1.1 = {
+		death = yes
+	}
+}
+
+160290 = {
+	name = "Sorkhab"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160289
+	700.1.1 = {
+		birth = yes
+	}
+	772.1.1 = {
+		death = yes
+	}
+}
+
+160291 = {
+	name = "Shervin"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160290
+	735.1.1 = {
+		birth = yes
+	}
+	817.1.1 = {
+		death = yes
+	}
+}
+
+160292 = {
+	name = "Shahryar"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160291
+	755.1.1 = {
+		birth = yes
+	}
+	825.1.1 = {
+		death = yes
+	}
+}
+
+160293 = {
+	name = "Shapur"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160292
+	790.1.1 = {
+		birth = yes
+	}
+	839.1.1 = {
+		death = yes
+	}
+}
+
+160294 = {
+	name = "Karen"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160292
+	795.1.1 = {
+		birth = yes
+	}
+	867.1.1 = {
+		death = yes
+	}
+}
+
+160295 = {
+	name = "Shervin"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 45105
+	865.1.1 = {
+		birth = yes
+	}
+	930.1.1 = {
+		death = yes
+	}
+}
+
+160286 = {
+	name = "Sorkhab"
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160294
+	846.1.1 = {
+		birth = yes
+	}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+160296 = {
+	name = "Qarin"
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160297
+	780.1.1 = {
+		birth = yes
+	}
+	816.1.1 = {
+		death = yes
+	}
+}
+
+160297 = {
+	name = "Vandad Hormozd"
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160298
+	trait = zealous
+	trait = tough_soldier
+	740.1.1 = {
+		birth = yes
+	}
+	815.1.1 = {
+		death = yes
+	}
+}
+
+188731 = {
+	name = "Vindaspagan" # historical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160298
+	trait = tough_soldier
+	741.1.1 = {
+		birth = yes
+	}
+	780.1.1 = {
+		death = yes
+	}
+}
+
+160298 = {
+	name = "Karen" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160299
+	680.1.1 = { #postponed from 660
+		birth = yes
+	}
+	742.1.1 = { #postponed from 737
+		death = yes
+	}
+}
+
+160299 = {
+	name = "Vandad" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160300
+	635.1.1 = {
+		birth = yes
+	}
+	700.1.1 = {
+		death = yes
+	}
+}
+
+160300 = {
+	name = "Balash"
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160301
+	600.1.1 = {
+		birth = yes
+	}
+	673.1.1 = {
+		death = yes
+	}
+}
+
+160301 = {
+	name = "Alanda"
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160302
+	560.1.1 = {
+		birth = yes
+	}
+	635.1.1 = {
+		death = yes
+	}
+}
+
+160302 = {
+	name = "Karen"
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160303
+	520.1.1 = {
+		birth = yes
+	}
+	600.1.1 = {
+		death = yes
+	}
+}
+
+160303 = {
+	name = "Sukhra"
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160304
+	480.1.1 = {
+		birth = yes
+	}
+	550.1.1 = {
+		death = yes
+	}
+}
+
+160304 = {
+	name = "Zarmihr" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160305
+	440.1.1 = {
+		birth = yes
+	}
+	500.1.1 = {
+		death = yes
+	}
+}
+
+160305 = {
+	name = "Alanda" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160306
+	410.1.1 = {
+		birth = yes
+	}
+	490.1.1 = {
+		death = yes
+	}
+}
+
+160306 = {
+	name = "Sukhra" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160307
+	370.1.1 = {
+		birth = yes
+	}
+	450.1.1 = {
+		death = yes
+	}
+}
+
+160307 = {
+	name = "Balash" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160308
+	335.1.1 = {
+		birth = yes
+	}
+	400.1.1 = {
+		death = yes
+	}
+}
+
+160308 = {
+	name = "Zarmihr" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160309
+	300.1.1 = {
+		birth = yes
+	}
+	375.1.1 = {
+		death = yes
+	}
+}
+
+160309 = {
+	name = "Karen" #unhistorical
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 159557 #Karen-Pahlav lineage
+	245.1.1 = {
+		birth = yes
+	}
+	330.1.1 = {
+		death = yes
+	}
+}
+
+216901 = {
+	name = "Paduspan"
+	dynasty = 7332
+	father = 216024 # perhaps
+	religion = zoroastrian
+	culture = persian
+	630.1.1 = {
+		birth = yes
+	}
+	694.1.1 = {
+		death = yes
+	}
+}
+
+216902 = {
+	name = "Khur-Zad"
+	dynasty = 7332
+	religion = zoroastrian
+	culture = persian
+	father = 216901
+	660.1.1 = {
+		birth = yes
+	}
+	723.1.1 = {
+		death = yes
+	}
+}
+
+216903 = {
+	name = "Paduspan"
+	dynasty = 7332
+	religion = zoroastrian
+	culture = persian
+	father = 216902
+	680.1.1 = {
+		birth = yes
+	}
+	762.1.1 = {
+		death = yes
+	}
+}
+
+216904 = {
+	name = "Shahriyar"
+	dynasty = 7332
+	religion = zoroastrian
+	culture = persian
+	father = 216903
+	trait = sympathy_islam
+	722.1.1 = {
+		birth = yes
+	}
+	791.1.1 = {
+		death = yes
+	}
+}
+
+216905 = {
+	name = "Wandad Umid"
+	dynasty = 7332
+	religion = zoroastrian
+	culture = persian
+	father = 216904
+	trait = sympathy_islam
+	750.1.1 = {
+		birth = yes
+	}
+	822.1.1 = {
+		death = yes
+	}
+}
+
+216906 = {
+	name = "Abdallah"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216905
+	trait = sympathy_zoroastrianism
+	775.1.1 = {
+		birth = yes
+	}
+	855.1.1 = {
+		death = yes
+	}
+}
+
+216907 = {
+	name = "Faridun"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216906
+	trait = sympathy_zoroastrianism
+	798.1.1 = {
+		birth = yes
+	}
+	855.1.1 = {
+		death = yes
+	}
+}
+
+216908 = {
+	name = "Paduspan"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216907
+	trait = sympathy_zoroastrianism
+	816.1.1 = {
+		birth = yes
+	}
+	872.1.1 = {
+		death = yes
+	}
+}
+
+216909 = {
+	name = "Shahriyar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216908
+	trait = sympathy_zoroastrianism
+	836.1.1 = {
+		birth = yes
+	}
+	887.1.1 = {
+		death = yes
+	}
+}
+
+216910 = {
+	name = "Hazar Sandan"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216909
+	trait = sympathy_zoroastrianism
+	854.1.1 = {
+		birth = yes
+	}
+	899.1.1 = {
+		death = yes
+	}
+}
+
+216911 = {
+	name = "Shahriyar"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216910
+	trait = sympathy_zoroastrianism
+	872.1.1 = {
+		birth = yes
+	}
+	938.1.1 = {
+		death = yes
+	}
+}
+
+216912 = {
+	name = "Shams al-Muluk"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216911
+	trait = sympathy_zoroastrianism
+	890.1.1 = {
+		birth = yes
+	}
+	965.1.1 = {
+		death = yes
+	}
+}
+
+216913 = {
+	name = "Istwandad"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216912
+	trait = sympathy_zoroastrianism
+	919.1.1 = {
+		birth = yes
+	}
+	980.1.1 = {
+		death = yes
+	}
+}
+
+216914 = {
+	name = "Fakhr al-Dawla"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216913
+	trait = sympathy_zoroastrianism
+	940.1.1 = {
+		birth = yes
+	}
+	980.1.1 = {
+		death = yes
+	}
+}
+
+216915 = {
+	name = "Hazarasp"
+	dynasty = 7332
+	religion = shiite
+	culture = persian
+	father = 216914
+	trait = sympathy_zoroastrianism
+	965.1.1 = {
+		birth = yes
+	}
+	1017.1.1 = {
+		death = yes
+	}
+}
+
+166987 = { #(Father of Mardavij/Vushmgir)
+	name = "Ziyar"
+	dynasty = 101689
+	religion = zoroastrian
+	culture = persian
+	840.6.6 = {
+		birth = yes
+	}
+	888.1.1 = {
+		add_spouse = 166988
+	}
+	900.2.17 = {
+		death = yes
+	}
+}
+
+166989 = {
+	name = "Mardavij"
+	dynasty = 101689
+	dna = bcedirmbfcy
+	properties = be00ca00000
+	religion = zoroastrian
+	culture = persian
+	father = 166987
+	mother = 166988
+	trait = brilliant_strategist
+	trait = ambitious
+	trait = zealous
+	trait = wroth
+	trait = deceitful
+	891.7.25 = {
+		birth = yes
+	}
+	930.1.1 = {
+		create_bloodline = {
+			type = mardavij
+			has_dlc = "Holy Fury"
+		}
+}
+
+	935.1.19 = {
+		death = yes
+	}
+}
+
+166990 = {
+	name = "Vushmgir"
+	dynasty = 101689
+	religion = sunni
+	properties = "asdebb"
+	culture = persian
+	father = 166987
+	mother = 166988
+	trait = skilled_tactician
+	trait = ambitious
+	trait = sympathy_zoroastrianism
+	trait = brave
+	trait = hunter
+	trait = gregarious
+	trait = siege_leader
+	898.3.13 = {
+		birth = yes
+			effect = { set_character_flag = is_vushmgir}
+}
+
+	923.1.1 = {
+			add_spouse = 166991
+}
+	936.1.1 = {
+		prestige = 350
+		piety = 230
+		wealth = 150
+}
+	967.1.1 = {
+		death = yes
+	}
+}
+
+166991 = {
+	name = "Elnaz"
+	female = yes
+	dynasty = 7331 # Bavandid
+	religion = zoroastrian
+	culture = persian
+	father = 160295
+	trait = scholarly_theologian
+	908.7.6 = {
+		birth = yes
+	}
+	989.4.7 = {
+		death = yes
+	}
+}
+
+166992 = {
+	name = "Bisutun"
+	dynasty = 101689
+	religion = sunni
+	culture = persian
+	father = 166990
+	mother = 166991
+	935.1.6 = {
+		birth = yes
+	}
+	977.8.6 = {
+		death = yes
+	}
+}
+
+166993 = {
+	name = "Qabus"
+	dynasty = 101689
+	religion = sunni
+	culture = persian
+	father = 166990
+	mother = 166991
+	940.4.17 = {
+		birth = yes
+	}
+	1012.6.11 = {
+		death = yes
+	}
+}
+
+166994 = {
+	name = "Manuchihr"
+	dynasty = 101689
+	religion = sunni
+	culture = persian
+	father = 166993
+	970.8.11 = {
+		birth = yes
+	}
+	1031.1.2 = {
+		death = yes
+	}
+}
+
+166995 = {
+	name = "Anushirvan Sharaf"
+	dynasty = 101689
+	religion = sunni
+	culture = persian
+	father = 166994
+	1001.4.19 = {
+		birth = yes
+	}
+	1050.1.2 = {
+		death = yes
+	}
+}
+
+166996 = {
+	name = "Eskander"
+	dynasty = 101689
+	religion = sunni
+	culture = persian
+	father = 166993
+	972.1.1 = {
+		birth = yes
+	}
+	1030.1.1 = {
+		death = yes
+	}
+}
+
+216013 = {
+	name = "Khurshid"
+	dynasty = 214020 # Dabuyid
+	father = 216020
+	religion = zoroastrian
+	culture = persian
+	734.1.1 = {
+		birth = yes
+	}
+	761.1.1 = {
+		death = yes
+	}
+}
+
+216014 = {
+	name = "Dadmihr"
+	dynasty = 214020 # Dabuyid
+	father = 216013
+	religion = zoroastrian
+	culture = persian
+	trait = skilled_tactician
+	trait = gregarious
+	751.1.1 = {
+		birth = yes
+	}
+	769.1.1 = {
+		employer = 244001 # according to chinese sources was in court of Tang
+		add_trait = sympathy_indian
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+216019 = {
+	name = "Hormazd"
+	dynasty = 214020 # Dabuyid
+	father = 216013
+	religion = zoroastrian
+	culture = persian
+	757.1.1 = {
+		birth = yes
+	}
+	761.1.1 = {
+		religion = sunni
+		trait = sympathy_zoroastrianism
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+216018 = {
+	name = "Vandad-Hormazd"
+	dynasty = 214020 # Dabuyid
+	father = 216013
+	religion = zoroastrian
+	culture = persian
+	759.1.1 = {
+		birth = yes
+	}
+	761.1.1 = {
+		religion = sunni
+		trait = sympathy_zoroastrianism
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+216015 = {
+	name = "Shakla"
+	female = yes
+	dynasty = 214020 # Dabuyid
+	father = 216013
+	religion = zoroastrian
+	culture = persian
+	753.1.1 = {
+		birth = yes
+	}
+	761.1.1 = {
+		religion = sunni
+		trait = sympathy_zoroastrianism
+	}
+	800.1.1 = {
+		death = yes
+	}
+}
+
+216020 = {
+	name = "Dadhburzmihr"
+	dynasty = 214020 # Dabuyid
+	father = 216021
+	religion = zoroastrian
+	culture = persian
+	710.1.1 = {
+		birth = yes
+	}
+	741.1.1 = {
+		death = yes
+	}
+}
+
+216021 = {
+	name = "Farrukhan"
+	dynasty = 214020 # Dabuyid
+	religion = zoroastrian
+	culture = persian
+	father = 216023
+	685.1.1 = {
+		birth = yes
+	}
+	728.1.1 = {
+		death = yes
+		give_nickname = nick_the_great
+}
+}
+
+216022 = {
+	name = "Farrukhan" # the Little
+	dynasty = 214020 # Dabuyid
+	father = 216021
+	religion = zoroastrian
+	culture = persian
+	trait = tough_soldier
+	trait = content
+	trait = diligent
+	trait = just
+	715.1.1 = {
+		birth = yes
+	}
+	769.1.1 = {
+		employer = 244001 # according to chinese sources was in court of Tang
+		add_trait = sympathy_indian
+		add_claim = d_mazandaran
+		add_claim = c_tabaristan
+		add_claim = c_alamut
+		add_claim = c_daylam
+	}
+	771.1.1 = {
+		death = yes
+	}
+}
+
+216023 = {
+	name = "Dabuya"
+	dynasty = 214020 # Dabuyid
+	father = 216024
+	religion = zoroastrian
+	culture = persian
+	640.1.1 = {
+		birth = yes
+	}
+	712.1.1 = {
+		death = yes
+	}
+}
+
+216024 = {
+	name = "Gavbarih"
+	dynasty = 214020 # Dabuyid
+	father = 216025
+	religion = zoroastrian
+	culture = persian
+	610.1.1 = {
+		birth = yes
+	}
+	660.1.1 = {
+		death = yes
+	}
+}
+
+216025 = {
+	name = "Peroz"
+	dynasty = 214020 # Dabuyid
+	father = 216026
+	religion = zoroastrian
+	culture = persian
+	575.1.1 = {
+		birth = yes
+	}
+	625.1.1 = {
+		death = yes
+	}
+}
+
+216026 = {
+	name = "Narsi"
+	dynasty = 214020 # Dabuyid
+	father = 180625 # perhaps
+	religion = zoroastrian
+	culture = persian
+	534.1.1 = {
+		birth = yes
+	}
+	600.1.1 = {
+		death = yes
+	}
+}
+
+248001 = {
+	name = "Keykhosraw" # Fictional local ruler
+	dynasty = 1059000
+	religion = khurmazta
+	culture = sogdian
+	trait = sympathy_indian
+	820.1.1 = {
+		birth = yes
+	}
+	#847.1.1 = {
+	#		add_spouse = 247696
+	#}
+	900.1.1 = {
+		death = yes
+	}
+}
+
+248002 = {
+	name = "Wakhushakk" # Fictional local ruler
+	dynasty = 1059000
+	religion = khurmazta
+	culture = sogdian
+	father = 248001
+	#mother = 247696
+	851.1.1 = {
+		birth = yes
+	}
+	915.1.1 = {
+		death = yes
+	}
+}
+
+248003 = {
+	name = "Kartir" # Fictional local ruler
+	dynasty = 1059000
+	religion = zoroastrian
+	culture = sogdian
+	father = 248002
+	882.1.1 = {
+		birth = yes
+	}
+	965.1.1 = {
+		death = yes
+	}
+}
+
+248004 = {
+	name = "Mahmud" # Fictional local ruler
+	dynasty = 1059000
+	religion = khurmazta
+	culture = sogdian
+	father = 248003
+	922.1.1 = {
+		birth = yes
+	}
+	950.1.1 = {
+		religion = shiite
+	}
+	951.1.1 = {
+		culture = persian # tajik
+	}
+	997.1.1 = {
+		death = yes
+	}
+}
+
+248005 = {
+	name = "Ismail" # Fictional local ruler
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248004
+	952.1.1 = {
+		birth = yes
+	}
+	1021.1.1 = {
+		death = yes
+	}
+}
+
+248011 = {
+	name = "Shahbeg"
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248004
+	960.1.1 = {
+		birth = yes
+	}
+	1035.1.1 = {
+		death = yes
+	}
+}
+
+248012 = {
+	name = "Yaribeg"
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248011
+	trait = brave
+	trait = strong
+	trait = tough_soldier
+	trait = mountain_terrain_leader
+	1030.1.1 = {
+		birth = yes
+	}
+	1077.1.1 = {
+		employer = 188419
+	}
+	1078.1.1 = {
+		trait = sympathy_indian
+	}
+	1118.1.1 = {
+		death = yes
+	}
+}
+
+248006 = {
+	name = "Nasr" # Fictional local ruler
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248005
+	977.1.1 = {
+		birth = yes
+	}
+	1038.1.1 = {
+		death = yes
+	}
+}
+
+248007 = {
+	name = "Ali bin al-Asad"
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	trait = sympathy_zoroastrianism
+	trait = sympathy_indian
+	trait = scholarly_theologian
+	father = 248006
+	1006.1.1 = {
+		birth = yes
+	}
+	1068.1.1 = {
+		death = yes
+	}
+}
+
+248008 = {
+	name = "Emad"
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248007
+	trait = cruel
+	trait = greedy
+	1050.1.1 = {
+		birth = yes
+	}
+	1099.1.1 = {
+		death = yes
+	}
+}
+
+248009 = {
+	name = "Zohreh"
+	female = yes
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248008
+	1077.1.1 = {
+		birth = yes
+	}
+	1140.1.1 = {
+		death = yes
+	}
+}
+
+248013 = {
+	name = "Suleiman"
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248012 #one of Yaribegs many sons but others have not been added to game
+	1060.1.1 = {
+		birth = yes
+	}
+	1135.1.1 = {
+		death = yes
+	}
+}
+
+248014 = {
+	name = "Behnaz"
+	female = yes
+	dynasty = 1059000
+	religion = shiite
+	culture = persian #tajik
+	father = 248013
+	1110.1.1 = {
+		birth = yes
+	}
+	1165.1.1 = {
+		death = yes
+	}
+}
+
+248015 = {
+	name = "Mirza" #fictional local ruler
+	dynasty = 1059006
+	religion = shiite
+	culture = persian #tajik
+	trait = tough_soldier
+	trait = greedy
+	trait = ambitious
+	trait = strong
+	1090.1.1 = {
+		birth = yes
+	}
+	1135.1.1 = {
+		add_spouse = 248014
+	}
+	1157.1.1 = {
+		death = yes
+	}
+}
+
+248016 = {
+	name = "Nasrid" #fictional local ruler
+	dynasty = 1059006
+	religion = shiite
+	culture = persian #tajik
+	mother = 248014
+	father = 248015
+	1137.1.1 = {
+		birth = yes
+	}
+	1197.1.1 = {
+		death = yes
+	}
+}
+
+248017 = {
+	name = "Manuchehr" #fictional local ruler
+	dynasty = 1059006
+	religion = shiite
+	culture = persian #tajik
+	father = 248016
+	1159.1.1 = {
+		birth = yes
+	}
+	1226.1.1 = {
+		death = yes
+	}
+}
+
+248018 = {
+	name = "Eskander" #fictional local ruler
+	dynasty = 1059006
+	religion = shiite
+	culture = persian #tajik
+	father = 248017
+	1190.1.1 = {
+		birth = yes
+	}
+	1239.1.1 = {
+		death = yes
+	}
+}
+
+248019 = {
+	name = "Kavoos" #fictional local ruler
+	dynasty = 1059006
+	religion = shiite
+	culture = persian #tajik
+	father = 248018
+	1210.1.1 = {
+		birth = yes
+	}
+	1275.1.1 = {
+		death = yes
+	}
+}
+
+248020 = {
+	name = "Taj Mughal"
+	dynasty = 1059006
+	religion = shiite
+	culture = persian #tajik
+	father = 248019
+	1250.1.1 = {
+		birth = yes
+	}
+	1325.1.1 = {
+		death = yes
+	}
+}
+
+248021 = {
+	name = "Armaghan"
+	dynasty = 1059006
+	religion = shiite
+	culture = persian #tajik
+	father = 248020
+	1300.1.1 = {
+		birth = yes
+	}
+	1370.1.1 = {
+		death = yes
+	}
+}
+
+248022 = {
+	name = "Nasir Khusraw"
+	dynasty = 0
+	religion = shiite
+	culture = persian
+	trait = physician
+	trait = poet
+	trait = gregarious
+	trait = scholarly_theologian
+	1004.1.1 = {
+		birth = yes
+	}
+	1053.1.1 = {
+		employer = 248007
+	}
+	1088.1.1 = {
+		death = yes
+	}
+}
+
+248044 = {
+	name = "Danush" # fictional local ruler
+	dynasty = 1059008
+	religion = buddhist
+	culture = persian #tajik
+	trait = vajrayana_buddhist
+	father = 248043
+	944.1.1 = {
+		birth = yes
+	}
+	1006.1.1 = {
+		death = yes
+	}
+}
+
+248045 = {
+	name = "Ardahan" # fictional local ruler
+	dynasty = 1059008
+	religion = buddhist
+	culture = persian #tajik
+	trait = vajrayana_buddhist
+	father = 248044
+	970.1.1 = {
+		birth = yes
+	}
+	1010.1.1 = {
+		religion = sunni # Kara-Khanid takeover Buddhism repressed
+	}
+	1042.1.1 = {
+		death = yes
+	}
+}
+
+248046 = {
+	name = "Rostam" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	trait = sympathy_indian
+	trait = tough_soldier
+	trait = mountain_terrain_leader
+	father = 248045
+	1010.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		effect = {
+			set_secret_religion	 = nestorian # Nestorian presence indicated in various sources.
+		}
+	}
+	1070.1.1 = {
+		death = yes
+	}
+}
+
+248047 = {
+	name = "Ardeshir" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248046
+	trait = skilled_tactician
+	trait = sympathy_indian
+	1032.1.1 = {
+		birth = yes
+	}
+	1066.1.1 = {
+		effect = {
+			set_secret_religion	 = nestorian # Nestorian presence indicated in various sources.
+		}
+	}
+	1098.1.1 = {
+		death = yes
+	}
+}
+
+248048 = {
+	name = "Ahmad" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248047
+	trait = sympathy_indian
+	1055.1.1 = {
+		birth = yes
+	}
+	1078.1.1 = {
+		effect = {
+			set_secret_religion	 = nestorian # Nestorian presence indicated in various sources.
+		}
+	}
+	1110.1.1 = {
+		death = yes
+	}
+}
+
+248049 = {
+	name = "Javeed" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248048
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1080.1.1 = {
+		birth = yes
+	}
+	1142.1.1 = {
+		death = yes
+	}
+}
+
+248050 = {
+	name = "Abbas" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248049
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1110.1.1 = {
+		birth = yes
+	}
+	1175.1.1 = {
+		death = yes
+	}
+}
+
+248051 = {
+	name = "Mahmud" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248050
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1140.1.1 = {
+		birth = yes
+	}
+	1210.1.1 = {
+		death = yes
+	}
+}
+
+248052 = {
+	name = "Sadri" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248051
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1180.1.1 = {
+		birth = yes
+	}
+	1239.1.1 = {
+		death = yes
+	}
+}
+
+248053 = {
+	name = "Ruhollas" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248052
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1205.1.1 = {
+		birth = yes
+	}
+	1280.1.1 = {
+		death = yes
+	}
+}
+
+248054 = {
+	name = "Kurush" # fictional
+	dynasty = 1059008
+	religion = nestorian
+	culture = persian #tajik
+	father = 248052
+	trait = sympathy_islam
+	trait = sympathy_indian
+	trait = legit_bastard
+	1222.1.1 = {
+		birth = yes
+	}
+	1300.1.1 = {
+		death = yes
+	}
+}
+
+248055 = {
+	name = "Hafez" # fictional local ruler
+	dynasty = 1059008
+	religion = sunni
+	culture = persian #tajik
+	father = 248053
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1240.1.1 = {
+		birth = yes
+	}
+	1310.1.1 = {
+		death = yes
+	}
+}
+
+248056 = {
+	name = "Farzad" # fictional local ruler
+	dynasty = 1059008
+	religion = shiite
+	culture = persian #tajik
+	father = 248055
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1270.1.1 = {
+		birth = yes
+	}
+	1337.1.1 = {
+		death = yes
+	}
+}
+
+248057 = {
+	name = "Khamush" # fictional local ruler
+	dynasty = 1059008
+	religion = shiite
+	culture = persian #tajik
+	father = 248056
+	trait = sympathy_christendom
+	trait = sympathy_indian
+	1295.1.1 = {
+		birth = yes
+	}
+	1350.1.1 = {
+		death = yes
+	}
+}
+
+248010 = {
+	name = "Hurmat" # fictional daughter of Khosrau I
+	female = yes
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180628
+	570.1.1 = {
+		birth = yes
+	}
+	630.1.1 = {
+		death = yes
+	}
+}
+
+242001 = {
+	name = "Saad Mordechai"
+	dynasty = 1059023
+	stewardship = 7
+	religion = sunni
+	secret_religion = jewish
+	culture = persian
+	trait = midas_touched
+	trait = ambitious
+	trait = physician
+	trait = patient
+	trait = brave
+	disallow_random_traits = yes
+	father = 248131
+	1240.1.1 = {
+		birth = yes
+	}
+	1283.1.1 = {
+		employer = 248137
+	}
+	1287.1.1 = {
+		employer = 478008
+	}
+	1291.1.1 = {
+		death = yes
+	}
+}
+
+248131 = {
+	name = "Hibbat" # real name unknown
+	dynasty = 1059023
+	religion = jewish
+	culture = persian
+	1200.1.1 = {
+		birth = yes
+	}
+	1250.1.1 = {
+		death = yes # murdered
+	}
+}
+
+248132 = {
+	name = "Mahdhdhib" # real name unknown
+	dynasty = 1059023
+	religion = jewish
+	culture = persian
+	father = 248131
+	1243.1.1 = {
+		birth = yes
+	}
+	1292.1.1 = {
+		death = yes # murdered
+	}
+}
+
+248133 = {
+	name = "Amin" # real name unknown
+	dynasty = 1059023
+	religion = jewish
+	culture = persian
+	father = 248131
+	1245.1.1 = {
+		birth = yes
+	}
+	1292.1.1 = {
+		death = yes # murdered
+	}
+}
+
+248134 = {
+	name = "Fakhr" # real name unknown
+	dynasty = 1059023
+	religion = jewish
+	culture = persian
+	father = 248131
+	1247.1.1 = {
+		birth = yes
+	}
+	1292.1.1 = {
+		death = yes # murdered
+	}
+}
+
+248165 = {
+	name = "Mahmud"
+	dynasty = 1059024
+	religion = sunni
+	culture = persian
+	trait = midas_touched
+	trait = sympathy_pagans
+	trait = content
+	1180.1.1 = {
+		birth = yes
+	}
+	1240.1.1 = {
+		death = yes # moved to China
+	}
+}
+
+248166 = {
+	name = "Masud-Beg"
+	dynasty = 1059024
+	religion = sunni
+	culture = persian
+	trait = midas_touched
+	trait = sympathy_pagans
+	father = 248165
+	1207.1.1 = {
+		birth = yes
+	}
+	1290.1.1 = {
+		death = yes # died sometime at end of 1289
+	}
+}
+
+248167 = {
+	name = "Abu Bakr"
+	dynasty = 1059024
+	religion = sunni
+	culture = persian
+	trait = sympathy_pagans
+	father = 248166
+	1227.1.1 = {
+		birth = yes
+	}
+	1298.1.1 = {
+		death = yes
+	}
+}
+
+248168 = {
+	name = "Satilmish-Beg"
+	dynasty = 1059024
+	religion = sunni
+	culture = persian
+	trait = sympathy_pagans
+	#father = 248154
+	1234.1.1 = {
+		birth = yes
+	}
+	1303.1.1 = {
+		death = yes
+	}
+}
+
+248169 = {
+	name = "Suyunitch"
+	dynasty = 1059024
+	religion = sunni
+	culture = persian
+	trait = sympathy_pagans
+	#father = 248154 #Time travel dad.
+	1260.1.1 = {
+		birth = yes
+	}
+	1338.1.1 = {
+		death = yes
+	}
+}
+
+248170 = {
+	name = "Vandad" # fictional son of Suyunitch
+	dynasty = 1059024
+	religion = sunni
+	culture = persian
+	trait = sympathy_pagans
+	father = 248169
+	1290.1.1 = {
+		birth = yes
+	}
+	1340.1.1 = {
+		death = yes
+	}
+}
+
+248216 = {
+	name = "Qutb ad-Din Habash"
+	dynasty = 0
+	religion = sunni
+	culture = persian
+	trait = grey_eminence
+	diplomacy = 10
+	1200.1.1 = {
+		birth = yes
+	}
+	1227.12.2 = {
+		employer = 93062
+	}
+	1260.1.1 = {
+		death = yes
+	}
+}
+
+248306 = {
+	name = "Hasim"
+	dynasty = 1059103
+	religion = sunni
+	culture = persian
+	800.1.1 = {
+		birth = yes
+	}
+	857.1.1 = {
+		death = yes
+	}
+}
+
+248307 = {
+	name = "Dawud ibn al-Abbas"
+	dynasty = 1059103
+	religion = sunni
+	culture = persian
+	father = 248306
+	822.1.1 = {
+		birth = yes
+	}
+	873.1.1 = {
+		death = yes
+	}
+}
+
+248308 = {
+	name = "Muhammad ibn Ahmad"
+	dynasty = 1059103
+	religion = sunni
+	culture = persian
+	father = 248307
+	853.1.1 = {
+		birth = yes
+	}
+	899.1.1 = {
+		death = yes
+	}
+}
+
+248309 = {
+	name = "Ahmad ibn Muhammad"
+	dynasty = 1059103
+	religion = sunni
+	culture = persian
+	father = 248308
+	870.1.1 = {
+		birth = yes
+	}
+	908.1.1 = {
+		death = yes
+	}
+}
+
+1059970 = {
+	name = "Vandad" # fictional son of Farrukhan
+	dynasty = 214020 # Dabuyid
+	religion = zoroastrian
+	culture = persian
+	father = 216022
+	745.1.1 = {
+		birth = yes
+	}
+	769.1.1 = {
+		employer = 244001
+		add_trait = sympathy_indian
+	}
+	775.1.1 = {
+		death = yes
+	}
+}
+
+1059968 = {
+	name = "Bahram" # Bahram VII claimant to Sassanid throne
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	father = 180637
+	647.1.1 = {
+		birth = yes
+	}
+	710.1.1 = {
+		death = yes
+	}
+}
+
+1059969 = {
+	name = "Khosrau" # reported son of Bahram VII
+	dynasty = 1029100
+	religion = zoroastrian
+	culture = persian
+	trait = tough_soldier
+	father = 1059968
+	677.1.1 = {
+		birth = yes
+	}
+	730.1.1 = {
+		culture = han
+		name = Juluo
+	}
+	740.1.1 = {
+		death = yes
+	}
+}
+
+248554 = {
+	name = "Rustam Dushmanziyar"
+	dynasty = 7331
+	religion = shiite
+	culture = persian
+	father = 220995
+	trait = ambitious
+	trait = skilled_tactician
+	trait = sympathy_zoroastrianism
+	970.1.1 = {
+		birth = yes # maybe
+	}
+	1028.1.1 = {
+		dynasty = 1059994 # establishes himself in Jibal
+	}
+	1041.1.1 = {
+		death = yes
+	}
+}
+
+248555 = {
+	name = "Faramurz"
+	dynasty = 1059994
+	religion = shiite
+	culture = persian
+	father = 248554
+	trait = charismatic_negotiator
+	trait = siege_leader
+	1020.1.1 = {
+		birth = yes # maybe
+	}
+	1066.1.1 = { # claims to lost territories
+		add_claim = d_jibal
+		add_claim = c_hamadan
+		add_claim = c_rayy
+		add_claim = c_qom
+		add_claim = c_esfahan
+	}
+	1072.11.1 = {
+		death = yes # unknown
+	}
+}
+
+248556 = {
+	name = "Garshap"
+	dynasty = 1059994
+	religion = shiite
+	culture = persian
+	father = 248554
+	1022.1.1 = {
+		birth = yes # maybe
+	}
+	1052.1.1 = {
+		death = yes
+	}
+}
+
+248557 = {
+	name = "Ali Faramurz"
+	dynasty = 1059994
+	religion = shiite
+	culture = persian
+	father = 248555
+	trait = gregarious
+	trait = charitable
+	1042.1.1 = {
+		birth = yes # maybe
+	}
+	1095.1.1 = {
+		death = yes # unknown
+	}
+}
+
+248558 = {
+	name = "Garshasp"
+	dynasty = 1059994
+	religion = shiite
+	culture = persian
+	father = 248557
+	trait = tough_soldier
+	1073.1.1 = {
+		birth = yes # maybe
+	}
+	1141.1.1 = {
+		death = yes
+	}
+}
+
+248559 = {
+	name = "Shirin" # unknown daughter
+	female = yes
+	dynasty = 1059994
+	religion = shiite
+	culture = persian
+	father = 248557
+	1120.1.1 = {
+		birth = yes # maybe
+	}
+	1152.1.1 = {
+		death = yes
+	}
+}
+
+248560 = {
+	name = "Wardanruz" # unknown originator of this dynasty
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	trait = skilled_tactician
+	1080.1.1 = {
+		birth = yes # maybe
+	}
+	1101.1.1 = {
+		employer = 248558
+	}
+	1138.1.1 = {
+		death = yes
+	}
+}
+
+248561 = {
+	name = "Sam Wardanruz"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248560
+	1121.1.1 = {
+		birth = yes # maybe
+	}
+	1188.1.1 = {
+		employer = 93167 # deposed by brother
+	}
+	1188.1.1 = {
+		add_claim = c_yazd
+	}
+	1193.1.1 = {
+		death = yes
+	}
+}
+
+248562 = {
+	name = "Langar Wardanruz"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248560
+	trait = ambitious
+	trait = tough_soldier
+	1123.1.1 = {
+		birth = yes # maybe
+	}
+	1142.1.1 = {
+		add_spouse = 248559 # to give marriage link to Kakuyids
+	}
+	1207.1.1 = {
+		death = yes #
+	}
+}
+
+248563 = {
+	name = "Wardanruz Langar"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248562
+	mother = 248559
+	1146.1.1 = {
+		birth = yes # maybe
+	}
+	1219.1.1 = {
+		death = yes
+	}
+}
+
+248564 = {
+	name = "Isfahsalar Langar"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248562
+	mother = 248559
+	1148.1.1 = {
+		birth = yes # maybe
+	}
+	1229.1.1 = {
+		death = yes
+	}
+}
+
+248566 = {
+	name = "Mahmud Shah Isfansalar"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248564
+	1170.1.1 = {
+		birth = yes # maybe
+	}
+	1241.1.1 = {
+		death = yes
+	}
+}
+
+248567 = {
+	name = "Salghur Shah"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248566
+	1195.1.1 = {
+		birth = yes # maybe
+	}
+	1252.1.1 = {
+		death = yes
+	}
+}
+
+248568 = {
+	name = "Tolghan Shah"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248567
+	1215.1.1 = {
+		birth = yes # maybe
+	}
+	1272.1.1 = {
+		death = yes
+	}
+}
+
+248569 = {
+	name = "Ala al-Dawla"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248568
+	1235.1.1 = {
+		birth = yes # maybe
+	}
+	1275.1.1 = {
+		death = yes
+	}
+}
+
+248570 = {
+	name = "Yusuf Shah"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248568
+	1235.1.1 = {
+		birth = yes # maybe
+	}
+	1293.1.1 = {
+		employer = 93172
+	}
+	1293.1.1 = {
+		add_claim = c_yazd
+	}
+	1297.1.1 = {
+		death = yes
+	}
+}
+
+248571 = {
+	name = "Hajji Shah"
+	dynasty = 1059993
+	religion = shiite
+	culture = persian
+	father = 248570
+	1260.1.1 = {
+		birth = yes # maybe
+	}
+	1297.1.1 = {
+		add_claim = c_yazd
+	}
+	1300.1.1 = {
+		employer = 93173
+	}
+	1315.1.1 = {
+		death = yes # deposed by Muzaffarids
+	}
+}
+
+248565 = {
+	name = "Zayn al-Din Gorgani" # famous doctor
+	dynasty = 0
+	religion = shiite
+	culture = persian
+	trait = temperate
+	trait = sympathy_zoroastrianism
+	trait = sympathy_christendom
+	trait = sympathy_judaism
+	trait = strong
+	trait = grey_eminence
+	trait = physician
+	trait = scholar
+	1041.1.1 = {
+		birth = yes # maybe
+	}
+	1066.1.1 = {
+		employer = 20703
+	}
+	1096.1.1 = {
+		employer = 144099
+	}
+	1130.1.1 = {
+		employer = 144015
+	}
+	1136.1.1 = {
+		death = yes
+	}
+}
+
+248618 = {
+	name = "Shansaban" # fictional
+	dynasty = 1059986
+	religion = buddhist
+	culture = persian
+	trait = mahayana_buddhist
+	trait = tough_soldier
+	trait = strong
+	750.1.1 = {
+		birth = yes # maybe
+	}
+	769.1.1 = {
+		employer = 188570 # Bamiyan
+	}
+	805.1.1 = {
+		death = yes
+	}
+}
+
+248619 = {
+	name = "Banji"
+	dynasty = 1059986
+	religion = buddhist
+	culture = persian
+	trait = mahayana_buddhist
+	trait = sympathy_islam # being legitimized by Caliph is likely medieval propaganda but we go with it
+	father = 248618
+	782.1.1 = {
+		birth = yes
+	}
+	866.1.1 = {
+		death = yes
+	}
+}
+
+248620 = {
+	name = "Amir"
+	dynasty = 1059986
+	religion = buddhist
+	culture = persian
+	trait = mahayana_buddhist
+	trait = sympathy_islam
+	trait = sympathy_pagans
+	trait = sympathy_zoroastrianism
+	trait = skilled_tactician
+	trait = strong
+	trait = brave
+	father = 248619
+	850.1.1 = {
+		birth = yes # maybe
+	}
+
+	867.1.1 = {
+		# Heathen tribes of Ghor
+		effect = {
+			spawn_unit = {
+				province = 907 # Mandesh
+				owner = ROOT
+				#leader = ROOT
+				troops = {
+					light_infantry = { 350 350 }
+					heavy_infantry = { 140 140 }
+					pikemen = { 40 40 }
+					archers = { 150 150 }
+					light_cavalry = { 40 40 }
+				}
+				attrition = 0.5
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = zoroastrian
+				culture = ROOT
+				female = no
+				age = 23
+				attributes = {
+					martial = 8
+				}
+				trait = tough_soldier
+			}
+			new_character = {
+				spawn_unit = {
+					province = 907 # Mandesh
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 350 350 }
+						heavy_infantry = { 140 140 }
+						pikemen = { 40 40 }
+						archers = { 150 150 }
+						light_cavalry = { 40 40 }
+					}
+					attrition = 0.5
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = zun_pagan
+				culture = ROOT
+				female = no
+				age = 27
+				attributes = {
+					martial = 8
+				}
+				trait = tough_soldier
+			}
+			new_character = {
+				spawn_unit = {
+					province = 907 # Mandesh
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_infantry = { 350 350 }
+						heavy_infantry = { 140 140 }
+						pikemen = { 40 40 }
+						archers = { 150 150 }
+						light_cavalry = { 40 40 }
+					}
+					attrition = 0.5
+				}
+			}
+		}
+	}
+
+	940.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248690 = {
+	name = "Varud" # fictional father of Tirdah
+	dynasty = 1059973
+	religion = zoroastrian
+	culture = persian
+	835.1.1 = {
+		birth = yes # maybe
+	}
+	867.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248691 = {
+	name = "Tirdadh" # historical ruler
+	dynasty = 1059973
+	religion = zoroastrian
+	culture = persian
+	father = 248690
+	trait = cynical
+	trait = proud
+	trait = tough_soldier
+	trait = ambitious
+	trait = sympathy_islam # representing efforts of Shiite missionaries
+	trait = sympathy_pagans
+	trait = sympathy_christendom
+	848.1.1 = {
+		birth = yes # maybe
+	}
+	900.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248692 = {
+	name = "Harusindan" # historical ruler
+	dynasty = 1059973
+	religion = zoroastrian
+	culture = persian
+	father = 248691
+	886.1.1 = {
+		birth = yes # maybe
+	}
+	922.1.1 = {
+		death = yes # maybe
+	}
+}
+
+166988 = { #(Mother of Mardavij, name unknown)
+	name = "Mahtab"
+	female = yes
+	dynasty = 1059973
+	religion = sunni
+	culture = persian
+	father = 248691
+	868.1.1 = {
+		birth = yes
+	}
+	905.1.1 = {
+		death = yes
+	}
+}
+
+248693 = {
+	name = "Siahgil" # historical ruler
+	dynasty = 1059973
+	religion = zoroastrian
+	culture = persian
+	father = 248692
+	904.1.1 = {
+		birth = yes # maybe
+	}
+	967.12.12 = {
+		death = yes # maybe
+	}
+}
+
+248694 = {
+	name = "Lili" # historical ruler
+	dynasty = 1059976
+	religion = zoroastrian
+	culture = persian
+	trait = brave
+	trait = tough_soldier
+	847.1.1 = {
+		birth = yes # maybe
+	}
+	867.1.1 = {
+		religion = shiite
+		trait = sympathy_zoroastrianism
+	}
+	921.1.1 = {
+		death = yes # maybe
+	}
+}
+
+248695 = {
+	name = "Hossein" # historical rebel mentioned
+	dynasty = 1059977
+	religion = shiite
+	culture = persian
+	trait = misguided_warrior
+	trait = zealous
+	846.1.1 = {
+		birth = yes
+	}
+	872.1.1 = {
+		death = yes
+	}
+}
+
+45105 = {
+	name = "Rostam" # Rostam II (was likely Muslim already in real history - his father Karen appears to have converted)
+	dynasty = 7331 # Bavandid
+	martial = 5
+	diplomacy = 6
+	intrigue = 6
+	stewardship = 6
+	religion = zoroastrian
+	culture = persian
+	trait = diligent
+	trait = just
+	trait = skilled_tactician
+	trait = sympathy_islam
+	father = 160294
+	845.1.1 = {
+		birth = yes
+	}
+	896.1.1 = {
+		death = yes
+	}
+}
+
+248697 = {
+	name = "Zakaria" # fictional brother of Tirdadh to represent remnants of Christianity among Dailamites
+	dynasty = 1059973
+	religion = nestorian
+	culture = persian
+	father = 248690
+	trait = sympathy_islam # representing efforts of Shiite missionaries
+	trait = sympathy_zoroastrianism
+	trait = sympathy_pagans
+	850.1.1 = {
+		birth = yes # maybe
+	}
+	904.1.1 = {
+		death = yes # maybe
+	}
+}
+
+261011 = {
+	name = "Buya"
+	dynasty = 1029008
+	religion = shiite
+	culture = persian
+	868.1.1 = {
+		birth = yes
+	}
+	890.1.1 = {
+		add_spouse = 261015
+	}
+	921.1.1 = {
+		death = yes
+	}
+}
+
+261012 = {
+	name = "Ali"
+	dynasty = 1029008
+	religion = shiite
+	culture = persian
+
+	disallow_random_traits = yes
+	trait = brilliant_strategist
+	trait = inspiring_leader
+	trait = mountain_terrain_leader
+	trait = ambitious
+	trait = patient
+	trait = temperate
+
+	diplomacy = 6
+	martial = 8
+	stewardship = 8
+	intrigue = 5
+	learning = 6
+
+	father = 261011
+	mother = 261015
+	892.1.1 = {
+		birth = yes
+	}
+	932.1.1 = {
+		prestige = 300
+		wealth = 350
+		effect = {
+			add_friend = 261013
+			add_friend = 261014
+		}
+	}
+	949.1.1 = {
+		death = yes
+	}
+}
+
+261013 = {
+	name = "Hasan"
+	dynasty = 1029008
+	religion = shiite
+	culture = persian
+
+	disallow_random_traits = yes
+	trait = skilled_tactician
+	trait = ambitious
+	trait = diligent
+	trait = just
+
+	diplomacy = 4
+	martial = 5
+	stewardship = 6
+	intrigue = 2
+	learning = 4
+
+	father = 261011
+	mother = 261015
+	898.1.1 = {
+		birth = yes
+	}
+	976.1.1 = {
+		death = yes
+	}
+}
+
+261014 = {
+	name = "Ahmad"
+	dynasty = 1029008
+	religion = shiite
+	culture = persian
+
+	disallow_random_traits = yes
+	trait = skilled_tactician
+	trait = ambitious
+	trait = diligent
+	trait = greedy
+
+	diplomacy = 6
+	martial = 5
+	stewardship = 7
+	intrigue = 5
+	learning = 5
+
+	father = 261011
+	mother = 261015
+	915.1.1 = {
+		birth = yes
+	}
+	936.1.1 = {
+		add_trait = one_handed
+	}
+	967.1.1 = {
+		death = yes
+	}
+}
+
+261015 = {
+	name = "Farrin"
+	female = yes
+	religion = shiite
+	culture = persian
+	871.1.1 = {
+		birth = yes
+	}
+	925.1.1 = {
+		death = yes
+	}
+}
+
+261016 = {
+	name = "Ahmad"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 163157
+	875.1.1 = {
+		birth = yes
+	}
+	914.1.1 = {
+		death = yes
+	}
+}
+
+261017 = {
+	name = "Nasr"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 261016
+	906.1.1 = {
+		birth = yes
+	}
+	943.1.1 = {
+		death = yes
+	}
+}
+
+261018 = {
+	name = "Nuh"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 261017
+	925.1.1 = {
+		birth = yes
+	}
+	954.1.1 = {
+		death = yes
+	}
+}
+
+261019 = {
+	name = "al-Layth"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 163165
+	870.1.1 = {
+		birth = yes
+	}
+	928.1.1 = {
+		death = yes
+	}
+}
+
+261020 = {
+	name = "Muhammad"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 163165
+	874.1.1 = {
+		birth = yes
+	}
+	911.1.1 = {
+		death = yes
+	}
+}
+
+261021 = {
+	name = "Al-Mu'addal"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 163165
+	880.1.1 = {
+		birth = yes
+	}
+	911.1.1 = {
+		death = yes
+	}
+}
+
+261022 = {
+	name = "Muhammad"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 261024
+	883.1.1 = {
+		birth = yes
+	}
+	915.1.1 = {
+		death = yes
+	}
+}
+
+261023 = {
+	name = "Ahmad"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 261022
+	906.1.1 = {
+		birth = yes
+	}
+	963.1.1 = {
+		death = yes
+	}
+}
+
+261024 = {
+	name = "Khalaf"
+	dynasty = 812
+	religion = sunni
+	culture = persian
+	father = 163163
+	857.1.1 = {
+		birth = yes
+	}
+	899.1.1 = {
+		death = yes
+	}
+}
+
+261025 = {
+	name = "Kaki"
+	dynasty = 1062492
+	religion = zoroastrian
+	culture = persian
+	875.1.1 = {
+		birth = yes
+	}
+	908.1.1 = {
+		death = yes
+	}
+}
+
+261026 = {
+	name = "Makan"
+	dynasty = 1062492
+	religion = zoroastrian
+	culture = persian
+	father = 261025
+	894.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+261034 = {
+	name = "Farighun"
+	dynasty = 1062497
+	religion = sunni
+	culture = persian
+	853.1.1 = {
+		birth = yes
+	}
+	919.1.1 = {
+		death = yes
+	}
+}
+
+261035 = {
+	name = "Ahmad"
+	dynasty = 1062497
+	religion = sunni
+	culture = persian
+	father = 261034
+	871.1.1 = {
+		birth = yes
+	}
+	928.1.1 = {
+		death = yes
+	}
+}
+
+261036 = {
+	name = "Abu'l Haret"
+	dynasty = 1062497
+	religion = sunni
+	culture = persian
+	father = 261035
+	903.1.1 = {
+		birth = yes
+	}
+	982.1.1 = {
+		death = yes
+	}
+}
+
+261037 = {
+	name = "Abu Bakr"
+	dynasty = 1062498
+	religion = sunni
+	culture = persian
+	874.1.1 = {
+		birth = yes
+	}
+	941.1.1 = {
+		death = yes
+	}
+}
+
+261038 = {
+	name = "Abu 'Ali"
+	dynasty = 1062498
+	religion = sunni
+	culture = persian
+	father = 261037
+	898.1.1 = {
+		birth = yes
+	}
+	955.1.1 = {
+		death = yes
+	}
+}
+
+261039 = {
+	name = "Abu'l Muzaffar"
+	dynasty = 1062498
+	religion = sunni
+	culture = persian
+	father = 261038
+	920.1.1 = {
+		birth = yes
+	}
+	952.1.1 = {
+		death = yes
+	}
+}
+
+261043 = {
+	name = "Abd-Allah"
+	dynasty = 1062499
+	religion = sunni
+	culture = persian
+	880.1.1 = {
+		birth = yes
+	}
+	920.1.1 = {
+		death = yes
+	}
+}
+
+261044 = {
+	name = "Abu'l-Abbas"
+	dynasty = 1062499
+	religion = sunni
+	culture = persian
+	father = 261043
+	913.1.1 = {
+		birth = yes
+	}
+	973.1.1 = {
+		death = yes
+	}
+}
+
+261045 = {
+	name = "Abu'l Fadl"
+	dynasty = 1062500
+	religion = sunni
+	culture = persian
+	884.1.1 = {
+		birth = yes
+	}
+	940.1.1 = {
+		death = yes
+	}
+}
+
+261046 = {
+	name = "Muhammad"
+	dynasty = 1062500
+	religion = sunni
+	culture = persian
+	father = 261045
+	918.1.1 = {
+		birth = yes
+	}
+	974.1.1 = {
+		death = yes
+	}
+}
+
+261047 = {
+	name = "Ilyas"
+	dynasty = 1062501
+	religion = sunni
+	culture = persian
+	876.1.1 = {
+		birth = yes
+	}
+	928.1.1 = {
+		death = yes
+	}
+}
+
+261048 = {
+	name = "Muhammad"
+	dynasty = 1062501
+	religion = sunni
+	culture = persian
+	father = 261047
+	895.1.1 = {
+		birth = yes
+	}
+	967.1.1 = {
+		death = yes
+	}
+}
+
+261049 = {
+	name = "Ilyasa"
+	dynasty = 1062501
+	religion = sunni
+	culture = persian
+	father = 261048
+	915.1.1 = {
+		birth = yes
+	}
+	968.1.1 = {
+		death = yes
+	}
+}
+
+261050 = {
+	name = "Sulaiman"
+	dynasty = 1062501
+	religion = sunni
+	culture = persian
+	father = 261048
+	920.1.1 = {
+		birth = yes
+	}
+	970.1.1 = {
+		death = yes
+	}
+}
+
+261051 = {
+	name = "Abdallah"
+	dynasty = 1062502
+	religion = sunni
+	culture = persian
+	858.1.1 = {
+		birth = yes
+	}
+	905.1.1 = {
+		death = yes
+	}
+}
+
+261052 = {
+	name = "Ali Yahya"
+	dynasty = 1062502
+	religion = sunni
+	culture = persian
+	father = 261051
+	889.1.1 = {
+		birth = yes
+	}
+	924.1.1 = {
+		death = yes
+	}
+}
+
+261053 = {
+	name = "Abu Makhlad"
+	dynasty = 1062502
+	religion = sunni
+	culture = persian
+	father = 261052
+	908.1.1 = {
+		birth = yes
+	}
+	961.1.1 = {
+		death = yes
+	}
+}
+
+261054 = {
+	name = "Fasanjas"
+	dynasty = 1062503
+	religion = sunni
+	culture = persian
+	854.1.1 = {
+		birth = yes
+	}
+	905.1.1 = {
+		death = yes
+	}
+}
+
+261055 = {
+	name = "Abu'l-Fadl"
+	dynasty = 1062503
+	religion = sunni
+	culture = persian
+	father = 261054
+	876.1.1 = {
+		birth = yes
+	}
+	953.1.1 = {
+		death = yes
+	}
+}
+
+261056 = {
+	name = "Abu'l-Faraj"
+	dynasty = 1062503
+	religion = sunni
+	culture = persian
+	father = 261055
+	909.1.1 = {
+		birth = yes
+	}
+	981.1.1 = {
+		death = yes
+	}
+}
+
+261057 = {
+	name = "Abu Muhammad"
+	dynasty = 1062503
+	religion = sunni
+	culture = persian
+	father = 261055
+	914.1.1 = {
+		birth = yes
+	}
+	968.1.1 = {
+		death = yes
+	}
+}
+
+261058 = {
+	name = "Muhammad"
+	dynasty = 1062504
+	religion = sunni
+	culture = persian
+	858.1.1 = {
+		birth = yes
+	}
+	905.1.1 = {
+		death = yes
+	}
+}
+
+261059 = {
+	name = "Abu'l-Hasan"
+	dynasty = 1062504
+	religion = sunni
+	culture = persian
+	father = 261058
+	880.1.1 = {
+		birth = yes
+	}
+	928.1.1 = {
+		death = yes
+	}
+}
+
+261060 = {
+	name = "al-Husayn"
+	dynasty = 1062504
+	religion = sunni
+	culture = persian
+	father = 261059
+	906.1.1 = {
+		birth = yes
+	}
+	967.1.1 = {
+		death = yes
+	}
+}
+
+261069 = {
+	name = "Ibrahim"
+	dynasty = 810
+	religion = sunni
+	culture = persian
+	father = 261016
+	911.1.1 = {
+		birth = yes
+	}
+	948.1.1 = {
+		death = yes
+	}
+}
+
+261099 = {
+	name = "Fereedun"
+	dynasty = 1062535
+	religion = sunni
+	culture = persian
+	910.1.1 = {
+		birth = yes
+	}
+	958.1.1 = {
+		death = yes
+	}
+}
+
+261100 = {
+	name = "Parviz"
+	dynasty = 1062536
+	religion = sunni
+	culture = persian
+	888.1.1 = {
+		birth = yes
+	}
+	945.1.1 = {
+		death = yes
+	}
+}
+
+261101 = {
+	name = "Ardavan"
+	dynasty = 1062537
+	religion = sunni
+	culture = persian
+	901.1.1 = {
+		birth = yes
+	}
+	951.1.1 = {
+		death = yes
+	}
+}
+
+261121 = {
+	name = "Aram"
+	dynasty = 1062552
+	religion = sunni
+	culture = persian
+	900.1.1 = {
+		birth = yes
+	}
+	961.1.1 = {
+		death = yes
+	}
+}
+
+261131 = {
+	name = "Javeed"
+	dynasty = 1062561
+	religion = sunni
+	culture = persian
+	908.1.1 = {
+		birth = yes
+	}
+	941.1.1 = {
+		death = yes
+	}
+}
+
+1059701 = {
+	name = "Reza" #Historical unnamed son of  Vandad
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 160297
+	782.1.1 = {
+		birth = yes
+	}
+	824.1.1 = {
+		death = yes
+	}
+}
+
+1059702 = {
+	name = "Vinda-Umid" #Historical uncle of Mazyar
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059701
+	800.1.1 = {
+		birth = yes
+	}
+	826.1.1 = {
+		death = yes
+	}
+}
+
+1059703 = {
+	name = "Gurdzad" #Possible historical member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059702
+	824.1.1 = {
+		birth = yes
+	}
+	867.1.1 = {
+		death = yes
+	}
+}
+
+1059704 = {
+	name = "Baduspan" #Historical member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059703
+	846.1.1 = {
+		birth = yes
+	}
+	910.1.1 = {
+		death = yes
+	}
+}
+
+1059705 = {
+	name = "Shahriyar" #Historical member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059704
+	trait = sympathy_islam
+	880.1.1 = {
+		birth = yes
+	}
+	917.1.1 = {
+		death = yes
+	}
+}
+
+1059706 = {
+	name = "Muhammad" # Historical member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059705
+	901.1.1 = {
+		birth = yes
+	}
+	936.1.1 = {
+		add_claim = c_daylam # historical claim
+	}
+	960.1.1 = {
+		death = yes # unknown
+	}
+}
+
+1059707 = {
+	name = "Vandad" # Fictional member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059706
+	930.1.1 = {
+		birth = yes
+	}
+	1000.1.1 = {
+		death = yes
+	}
+}
+
+1059708 = {
+	name = "Qarin" # Fictional member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059707
+	960.1.1 = {
+		birth = yes
+	}
+	1020.1.1 = {
+		death = yes
+	}
+}
+
+1059709 = {
+	name = "Shahriyar" # Fictional member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059708
+	990.1.1 = {
+		birth = yes
+	}
+	1050.1.1 = {
+		death = yes
+	}
+}
+
+1059710 = {
+	name = "Mazyar" # Fictional member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059709
+	1020.1.1 = {
+		birth = yes
+	}
+	1070.1.1 = {
+		death = yes
+	}
+}
+
+1059711 = {
+	name = "Balash" # Fictional member of Karen dynasty
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059710
+	1050.1.1 = {
+		birth = yes
+	}
+	1105.1.1 = {
+		death = yes
+	}
+}
+
+1059712 = {
+	name = "Amir" # Last known ruler of house Karen
+	dynasty = 7511
+	religion = zoroastrian
+	culture = persian
+	father = 1059710
+	1090.1.1 = {
+		birth = yes
+	}
+	1130.1.1 = {
+		death = yes
+	}
+}
+
+1059713 = {
+	name = "Quhyar" # Historical
+	dynasty = 7511
+	martial = 7
+	religion = zoroastrian
+	culture = persian
+	trait = deceitful
+	trait = sympathy_islam
+	father = 160296
+	802.1.1 = {
+		birth = yes
+	}
+	839.1.1 = {
+		death = yes # Killed by his own soldiers
+	}
+}
+
+# Ruzbahan
+261339 = {
+	name = Vindad # historical
+	dynasty = 1062594
+	religion = shiite
+	secret_religion = zoroastrian
+	culture = persian
+	900.1.1 = {
+		birth = yes # maybe
+	}
+	945.1.1 = {
+		death = yes # yes
+	}
+}
+
+261340 = {
+	name = Ruzbahan # historical
+	dynasty = 1062594
+	religion = shiite
+	secret_religion = zoroastrian
+	culture = persian
+	father = 261339
+	trait = proud
+	trait = greedy
+	trait = tough_soldier
+	918.1.1 = {
+		birth = yes # maybe
+	}
+	958.1.1 = {
+		death = yes # yes
+	}
+}
+
+261341 = {
+	name = Asfar # historical
+	dynasty = 1062594
+	religion = shiite
+	culture = persian
+	father = 261339
+	920.1.1 = {
+		birth = yes # maybe
+	}
+	958.1.1 = {
+		death = yes # maybe
+	}
+}
+
+261342 = {
+	name = Bullaka # historical
+	dynasty = 1062594
+	religion = zoroastrian
+	culture = persian
+	father = 261339
+	trait = sympathy_zoroastrianism
+	922.1.1 = {
+		birth = yes # maybe
+	}
+	958.1.1 = {
+		death = yes # maybe
+	}
+}


### PR DESCRIPTION
This corrects some dynasties who have overlapping ids, or whose ids would overlap with our range, in one case.

I ensured that, for dynasties where there wasn't a duplicate of the same name without the same id, their ids were unused by another dynasty. Additionally, I ensured these unused dynasty ids were *also* unused by unconnected characters in the vanilla character history (that is, characters who have a declared dynasty, but whose declared dynasty id doesn't have a corresponding entry in the dynasties file).