### PR TITLE
Make Boats Necessary

### DIFF
--- a/CK2Plus_expanded/map/adjacencies.csv
+++ b/CK2Plus_expanded/map/adjacencies.csv
@@ -1,0 +1,259 @@
+From;To;Type;Through;-1;-1;-1;-1;Comment
+496;741;sea;947;-1;-1;-1;-1;Constantinople-Nikomedia
+259;261;major_river;1046;-1;-1;-1;-1;Celle-Hamburg			#ELBE
+258;261;major_river;1046;-1;-1;-1;-1;Lüneburg-Hamburg
+309;261;major_river;1046;-1;-1;-1;-1;Altmark-Hamburg
+309;262;major_river;1046;-1;-1;-1;-1;Altmark-Lübeck
+309;260;major_river;1047;-1;-1;-1;-1;Altmark-Mecklenburg
+309;1988;major_river;1047;-1;-1;-1;-1;Werben-Havelberg
+1982;1988;major_river;1048;-1;-1;-1;-1;Magdeburg-Havelberg
+1982;310;major_river;1048;-1;-1;-1;-1;Magdeburg-Zerbst
+311;364;major_river;1048;-1;-1;-1;-1;Merseburg-Lausitz
+311;310;major_river;1048;-1;-1;-1;-1;Merseburg-Zerbst
+312;364;major_river;1049;-1;-1;-1;-1;Meissen-Lausitz
+312;1589;major_river;1049;-1;-1;-1;-1;Meissen-Gorlitz
+1589;1926;major_river;1049;-1;-1;-1;-1;Gorlitz-Zatec
+363;1926;major_river;1049;-1;-1;-1;-1;Litomerice-Zatec
+80;92;major_river;1043;-1;-1;-1;-1;Holland-Breda		#RHINE
+82;92;major_river;1043;-1;-1;-1;-1;Sticht-Breda
+89;91;major_river;1043;-1;-1;-1;-1;Kleve-Loon
+119;89;major_river;1044;-1;-1;-1;-1;Köln-Kleve
+119;1983;major_river;1044;-1;-1;-1;-1;Köln-Berg
+118;1983;major_river;1045;-1;-1;-1;-1;Trier-Berg
+1981;118;major_river;1045;-1;-1;-1;-1;Frankfurt-Trier
+97;99;major_river;1041;-1;-1;-1;-1;Rouen-Evreux		#SEINE
+98;99;major_river;1041;-1;-1;-1;-1;Vexin-Evreux
+1961;99;major_river;1041;-1;-1;-1;-1;Clermont-Evreux
+1961;112;major_river;1042;-1;-1;-1;-1;Clermont-Paris
+106;1957;major_river;1039;-1;-1;-1;-1;Nantes-Retz
+107;1959;major_river;1039;-1;-1;-1;-1;Anjou-Saumur
+107;140;major_river;1040;-1;-1;-1;-1;Anjou-Tours
+109;140;major_river;1040;-1;-1;-1;-1;Vendome-Tours
+143;149;major_river;1107;-1;-1;-1;-1;Saintonge-Bordeaux		#GARONNE
+216;149;major_river;1107;-1;-1;-1;-1;Perigord-Bordeaux
+216;215;major_river;1108;-1;-1;-1;-1;Perigord-Agen
+214;215;major_river;1108;-1;-1;-1;-1;Toulouse-Agen
+368;370;major_river;1051;-1;-1;-1;-1;Gdansk-Marienburg		#VISTULA
+368;369;major_river;1051;-1;-1;-1;-1;Gdansk-Chelmno
+368;1581;major_river;1052;-1;-1;-1;-1;Gdansk-Dobrzyn
+1581;429;major_river;1052;-1;-1;-1;-1;Dobrzyn-Naklo
+1581;428;major_river;1052;-1;-1;-1;-1;Dobrzyn-Kujawy
+528;529;major_river;1053;-1;-1;-1;-1;Czersk-Plock
+528;530;major_river;1054;-1;-1;-1;-1;Czersk-Liw
+531;530;major_river;1054;-1;-1;-1;-1;Sandomierz-Liw
+531;1584;major_river;1054;-1;-1;-1;-1;Sandomierz-Stezyca
+531;1585;major_river;1054;-1;-1;-1;-1;Sandomierz-Lublin
+531;532;major_river;1055;-1;-1;-1;-1;Sandomierz-Sacz
+1596;1592;major_river;1080;-1;-1;-1;-1;Riga-Tukums		#DAUGAVA
+1596;374;major_river;1080;-1;-1;-1;-1;Riga-Zemigaliens
+1594;374;major_river;1080;-1;-1;-1;-1;Jersika-Zemigaliens
+1594;1591;major_river;1080;-1;-1;-1;-1;Jersika-Selija
+416;1591;major_river;1081;-1;-1;-1;-1;WestDvina-Selija
+416;934;major_river;1081;-1;-1;-1;-1;WestDvina-Lepiel
+419;934;major_river;1081;-1;-1;-1;-1;Polotsk-Lepiel
+419;417;major_river;1082;-1;-1;-1;-1;Polotsk-Vitebsk
+419;568;major_river;1082;-1;-1;-1;-1;Polotsk-Smolensk
+410;568;major_river;1082;-1;-1;-1;-1;Toropets-Smolensk
+392;411;major_river;1083;-1;-1;-1;-1;Kexholm-Ingriya		#NEVA & SVIR
+392;409;major_river;1083;-1;-1;-1;-1;Kexholm-Ladoga
+393;1660;major_river;1084;-1;-1;-1;-1;Olonets-Chlisselbourg
+393;404;major_river;1084;-1;-1;-1;-1;Olonets-Zaozerye
+1660;409;major_river;1085;-1;-1;-1;-1;Chlisselbourg-Ladoga	#VOLKHOV & LOVAT
+1652;409;major_river;1085;-1;-1;-1;-1;Borovichi-Ladoga
+1652;414;major_river;1085;-1;-1;-1;-1;Borovichi-Novgorod
+1667;1662;major_river;1087;-1;-1;-1;-1;Kholm-Rusa
+410;1662;major_river;1087;-1;-1;-1;-1;Toropets-Rusa
+410;415;major_river;1087;-1;-1;-1;-1;Toropets-Luki
+543;558;major_river;1070;-1;-1;-1;-1;Lower Dnieper-Oleshye	#DNIEPER
+543;557;major_river;1070;-1;-1;-1;-1;Lower Dnieper-Lukomorie
+543;557;major_river;1071;-1;-1;-1;-1;Lower Dnieper-Chortitza
+543;1658;major_river;1071;-1;-1;-1;-1;Lower Dnieper-Hradyzk
+544;1658;major_river;1071;-1;-1;-1;-1;Korsun-Hradyzk
+544;1657;major_river;1072;-1;-1;-1;-1;Korsun-Voin
+547;1657;major_river;1072;-1;-1;-1;-1;Kiev-Voin
+547;555;major_river;1072;-1;-1;-1;-1;Kiev-Pereyaslavl
+547;554;major_river;1072;-1;-1;-1;-1;Kiev-Chernigov
+1653;554;major_river;1076;-1;-1;-1;-1;Slutsk-Chernigov
+1659;553;major_river;1076;-1;-1;-1;-1;Drutsk-Lyubech
+1659;551;major_river;1077;-1;-1;-1;-1;Drutsk-Mstislavl
+418;551;major_river;1077;-1;-1;-1;-1;Orsha-Mstislavl
+417;551;major_river;1078;-1;-1;-1;-1;Vitebsk-Mstislavl
+568;551;major_river;1078;-1;-1;-1;-1;Smolensk-Mstislavl
+568;569;major_river;1078;-1;-1;-1;-1;Smolensk-Vyazma
+1653;1649;major_river;1626;-1;-1;-1;-1;Slutsk-Korosten		#PRIPYAT
+1653;552;major_river;1079;-1;-1;-1;-1;Slutsk-Turov
+548;552;major_river;1079;-1;-1;-1;-1;Pinsk-Turov
+548;535;major_river;1079;-1;-1;-1;-1;Pinsk-Volodymyr
+554;555;major_river;1073;-1;-1;-1;-1;Chernigov-Pereyaslavl	#DESNA
+554;1675;major_river;1073;-1;-1;-1;-1;Chernigov-Priluk
+1656;567;major_river;1074;-1;-1;-1;-1;Starodub-Novgorod Seversky
+576;1676;major_river;1074;-1;-1;-1;-1;Bryansk-Kromy
+576;1666;major_river;1074;-1;-1;-1;-1;Bryansk-Karachev
+933;1666;major_river;1074;-1;-1;-1;-1;Roslavl-Karachev
+596;597;major_river;1088;-1;-1;-1;-1;Tana-Azov		#DON
+596;599;major_river;1088;-1;-1;-1;-1;Tana-Kuban
+596;607;major_river;1088;-1;-1;-1;-1;Tana-Sarpa
+594;607;major_river;1088;-1;-1;-1;-1;Sarkel-Sarpa
+594;605;major_river;1089;-1;-1;-1;-1;Sarkel-Manych
+594;595;major_river;1090;-1;-1;-1;-1;Sarkel-DonPortage
+594;593;major_river;1090;-1;-1;-1;-1;Sarkel-Khopyor
+566;593;major_river;1091;-1;-1;-1;-1;Sugrov-Khopyor
+566;579;major_river;1091;-1;-1;-1;-1;Sugrov-Mordva
+1665;579;major_river;1091;-1;-1;-1;-1;Yelets-Mordva
+1665;577;major_river;1091;-1;-1;-1;-1;Yelets-Pronsk
+620;604;major_river;1092;-1;-1;-1;-1;Itil-Kuma		#VOLGA
+619;604;major_river;1092;-1;-1;-1;-1;Saray-Kuma
+619;605;major_river;1093;-1;-1;-1;-1;Saray-Manych
+1812;595;major_river;1094;-1;-1;-1;-1;Saqsin-DonPortage
+1812;605;major_river;1094;-1;-1;-1;-1;Saqsin-Manych
+1814;595;major_river;1094;-1;-1;-1;-1;Uvek-DonPortage
+1814;592;major_river;1094;-1;-1;-1;-1;Uvek-Burtasy
+1814;609;major_river;1103;-1;-1;-1;-1;Uvek-Syrt
+608;609;major_river;1103;-1;-1;-1;-1;LowerVolga-Syrt
+616;609;major_river;1095;-1;-1;-1;-1;Pecheneg-Syrt
+610;609;major_river;1096;-1;-1;-1;-1;Bolghar-Syrt
+610;614;major_river;1096;-1;-1;-1;-1;Bolghar-Ashli
+611;614;major_river;1096;-1;-1;-1;-1;Qazan-Ashli
+611;589;major_river;1096;-1;-1;-1;-1;Qazan-Kerzhenets
+589;590;major_river;1097;-1;-1;-1;-1;Kerzhenets-Chuvash
+585;584;major_river;1098;-1;-1;-1;-1;Gorodets-NizhnyNovgorod
+585;582;major_river;1098;-1;-1;-1;-1;Gorodets-Vladimir
+407;582;major_river;1099;-1;-1;-1;-1;Kostroma-Vladimir
+407;583;major_river;1099;-1;-1;-1;-1;Kostroma-Suzdal
+407;572;major_river;1099;-1;-1;-1;-1;Kostroma-Yaroslavl
+407;571;major_river;1100;-1;-1;-1;-1;Kostroma-Uglich
+407;408;major_river;1100;-1;-1;-1;-1;Kostroma-Belozero
+406;408;major_river;1101;-1;-1;-1;-1;Vologda-Belozero
+405;408;major_river;1101;-1;-1;-1;-1;Chud-Belozero
+403;408;major_river;1101;-1;-1;-1;-1;Romny-Belozero
+403;404;major_river;1101;-1;-1;-1;-1;Romny-Zaozerye
+584;582;major_river;1102;-1;-1;-1;-1;NizhnyNovgorod-Vladimir		#OKA
+591;581;major_river;1102;-1;-1;-1;-1;Cheremisa-Murom
+580;581;major_river;1104;-1;-1;-1;-1;Ryazan-Murom
+580;1678;major_river;1104;-1;-1;-1;-1;Ryazan-OrekhovoOulevo
+578;1678;major_river;1104;-1;-1;-1;-1;Tula-OrekhovoOulevo
+1679;1677;major_river;1673;-1;-1;-1;-1;Serpukhov-NaroFominsk
+1679;587;major_river;1673;-1;-1;-1;-1;Serpukhov-Mozhaysk
+1650;587;major_river;1673;-1;-1;-1;-1;Vorotynsk-Mozhaysk
+1650;1682;major_river;1674;-1;-1;-1;-1;Vorotynsk-Kozelsk
+1650;1666;major_river;1674;-1;-1;-1;-1;Vorotynsk-Karachev
+1677;1678;major_river;1105;-1;-1;-1;-1;NaroFominsk-OrekhovoOulevo
+1677;575;major_river;1105;-1;-1;-1;-1;NaroFominsk-Moskva
+1677;1669;major_river;1105;-1;-1;-1;-1;NaroFominsk-Kashin
+570;1669;major_river;1106;-1;-1;-1;-1;Tver-Kashin
+570;1668;major_river;1106;-1;-1;-1;-1;Tver-Rzheva
+1672;1668;major_river;1106;-1;-1;-1;-1;Zoubtsov-Rzheva
+410;1668;major_river;1106;-1;-1;-1;-1;Toropets-Rzheva
+410;412;major_river;1106;-1;-1;-1;-1;Toropets-Torzhok
+610;611;major_river;1628;-1;-1;-1;-1;Bolghar-Qazan		#KAMA
+610;1716;major_river;1628;-1;-1;-1;-1;Bolghar-Kremenchuk
+613;1716;major_river;1628;-1;-1;-1;-1;Bilyar-Kremenchuk
+613;1717;major_river;1628;-1;-1;-1;-1;Bilyar-Alabuga
+436;1717;major_river;1628;-1;-1;-1;-1;Naberezhnye-Alabuga
+1646;512;major_river;1056;-1;-1;-1;-1;Odessa-Belgorod		#DNIESTER
+1646;541;major_river;1056;-1;-1;-1;-1;Odessa-Peresechen
+1641;541;major_river;1057;-1;-1;-1;-1;Bratslav-Peresechen
+1637;541;major_river;1057;-1;-1;-1;-1;Ushytsia-Peresechen
+1637;1638;major_river;1057;-1;-1;-1;-1;Ushytsia-Iasi
+1637;536;major_river;1627;-1;-1;-1;-1;Ushytsia-Galich
+546;536;major_river;1627;-1;-1;-1;-1;Terebovl-Galich
+510;1640;major_river;1058;-1;-1;-1;-1;Constantia-Chilia		#DANUBE
+510;511;major_river;1058;-1;-1;-1;-1;Constantia-Galaz
+510;1642;major_river;1058;-1;-1;-1;-1;Constantia-Calarasi
+509;1642;major_river;1059;-1;-1;-1;-1;Karvuna-Calarasi
+509;514;major_river;1059;-1;-1;-1;-1;Karvuna-Turnu
+508;514;major_river;1059;-1;-1;-1;-1;Dorostotum-Turnu
+507;514;major_river;1060;-1;-1;-1;-1;Nikopolis-Turnu
+507;1643;major_river;1060;-1;-1;-1;-1;Nikopolis-Craiova
+506;1643;major_river;1061;-1;-1;-1;-1;Vidin-Craiova
+506;1645;major_river;1061;-1;-1;-1;-1;Vidin-Targu Jiu
+506;516;major_river;1061;-1;-1;-1;-1;Vidin-Severin
+505;516;major_river;1061;-1;-1;-1;-1;Belgrade-Severin
+505;517;major_river;1063;-1;-1;-1;-1;Beograd-Temes
+505;518;major_river;1063;-1;-1;-1;-1;Beograd-Bacs
+1968;517;major_river;1063;-1;-1;-1;-1;Syrmia-Temes
+1968;518;major_river;1063;-1;-1;-1;-1;Syrmia-Bacs
+452;518;major_river;1065;-1;-1;-1;-1;Pecs-Bacs
+452;521;major_river;1065;-1;-1;-1;-1;Pecs-Csanad
+452;522;major_river;1065;-1;-1;-1;-1;Pecs-Pest
+451;522;major_river;1066;-1;-1;-1;-1;Fejer-Pest
+451;444;major_river;1066;-1;-1;-1;-1;Fejer-Esztergom
+450;444;major_river;1067;-1;-1;-1;-1;Sopron-Esztergom
+450;445;major_river;1067;-1;-1;-1;-1;Sopron-Pressburg
+449;445;major_river;1067;-1;-1;-1;-1;Österreich-Pressburg
+449;1697;major_river;1067;-1;-1;-1;-1;Österreich-Krems
+1699;1697;major_river;1067;-1;-1;-1;-1;Medelike-Krems
+1699;1698;major_river;1067;-1;-1;-1;-1;Medelike-Freistadt
+448;447;major_river;1068;-1;-1;-1;-1;Salzburg-Passau
+1700;447;major_river;1068;-1;-1;-1;-1;Regensburg-Passau
+1690;1698;major_river;1068;-1;-1;-1;-1;Traungau-Freistadt
+1700;361;major_river;1068;-1;-1;-1;-1;Regensburg-Niederbayern
+1700;252;major_river;1069;-1;-1;-1;-1;Regensburg-Ulm
+315;252;major_river;1069;-1;-1;-1;-1;Kempten-Ulm
+249;252;major_river;1069;-1;-1;-1;-1;Schwaben-Ulm
+249;251;major_river;1069;-1;-1;-1;-1;Schwaben-Fürstenberg
+1297;1331;major_river;1307;-1;-1;-1;-1;Debul-Sonda
+1303;1331;major_river;1307;-1;-1;-1;-1;Ranikot-Sonda
+1303;1137;major_river;1307;-1;-1;-1;-1;Ranikot-Mansura
+1303;1333;major_river;1308;-1;-1;-1;-1;Ranikot-Siwistan
+1138;1333;major_river;1308;-1;-1;-1;-1;Bhakkar-Siwistan
+1138;1175;major_river;1309;-1;-1;-1;-1;Bhakkar-Aror
+1339;1175;major_river;1309;-1;-1;-1;-1;Rajanpur-Aror
+1339;1336;major_river;1309;-1;-1;-1;-1;Rajanpur-Vijnot
+1339;1337;major_river;1310;-1;-1;-1;-1;Rajanpur-Uch
+1375;1337;major_river;1310;-1;-1;-1;-1;Kafirkot-Uch
+1375;1338;major_river;1310;-1;-1;-1;-1;Kafirkot-Multan
+1375;1340;major_river;1310;-1;-1;-1;-1;Kafirkot-Karor
+1191;1340;major_river;1310;-1;-1;-1;-1;Bannu-Karor
+1236;1318;major_river;1311;-1;-1;-1;-1;Candradvipa-Samatata
+1236;1319;major_river;1311;-1;-1;-1;-1;Candradvipa-Bikrampur
+1240;1319;major_river;1311;-1;-1;-1;-1;Kumara Mandala-Bikrampur
+1240;1325;major_river;1312;-1;-1;-1;-1;Kumara Mandala-Madhupur
+1243;1151;major_river;1312;-1;-1;-1;-1;Gauda-Laksmanavati
+1243;1153;major_river;1313;-1;-1;-1;-1;Gauda-Kotivarsa
+1152;1153;major_river;1313;-1;-1;-1;-1;Mudgagiri-Kotivarsa
+1152;1419;major_river;1313;-1;-1;-1;-1;Mudgagiri-Mithila
+1154;1419;major_river;1313;-1;-1;-1;-1;Magadha-Mithila
+1154;1162;major_river;1313;-1;-1;-1;-1;Magadha-Kusinagara
+1251;1162;major_river;1315;-1;-1;-1;-1;Sasaram-Kusinagara
+1251;1166;major_river;1315;-1;-1;-1;-1;Sasaram-Jaunpur
+1251;1163;major_river;1315;-1;-1;-1;-1;Sasaram-Varanasi
+1281;1163;major_river;1315;-1;-1;-1;-1;Chunar-Varanasi
+1328;1163;major_river;1315;-1;-1;-1;-1;Prayaga-Varanasi
+1328;1284;major_river;1315;-1;-1;-1;-1;Prayaga-Bharauli
+1283;1284;major_river;1315;-1;-1;-1;-1;Asni-Bharauli
+1356;1284;major_river;1314;-1;-1;-1;-1;Kanyakubja-Bharauli
+1356;1167;major_river;1314;-1;-1;-1;-1;Kanyakubja-Lakhnau
+1356;1358;major_river;1314;-1;-1;-1;-1;Kanyakubja-Vodamayutja
+1141;1358;major_river;1314;-1;-1;-1;-1;Kol-Vodamayutja
+1141;1173;major_river;1314;-1;-1;-1;-1;Kol-Sambhal
+1365;1173;major_river;1314;-1;-1;-1;-1;Delhi-Sambhal
+1325;1319;major_river;1316;-1;-1;-1;-1;Madhupur-Bikrampur
+1325;1324;major_river;1316;-1;-1;-1;-1;Madhupur-Suvarnagram
+1381;1324;major_river;1316;-1;-1;-1;-1;Pundravardhana-Suvarnagram
+1321;1246;major_river;1317;-1;-1;-1;-1;Kamarupanagara-Goalpara
+1078;1082;portage;568;-1;-1;-1;-1;Dneiper-Dwina		###PORTAGE
+1089;1093;portage;595;-1;-1;-1;-1;Don-Volga
+1087;1082;portage;419;-1;-1;-1;-1;Lovat-Dwina
+1402;1404;portage;1195;-1;-1;-1;-1;Gulf of Mannar-Palk Strait
+45;1939;sea;992;-1;-1;-1;-1;Argyll - Iona
+1939;35;sea;992;-1;-1;-1;-1;Iona - Innse Gall
+64;1949;sea;968;-1;-1;-1;-1;Gwynedd - Anglesey
+26;1950;sea;966;-1;-1;-1;-1;Wessex - Wight
+798;799;major_river;1995;-1;-1;-1;-1;Damietta - Rasheed # Nile
+797;799;major_river;1995;-1;-1;-1;-1;El-Malhalla - Rasheed # Nile
+797;2004;major_river;1995;-1;-1;-1;-1;El-Malhalla - Kharibta # Nile
+796;2004;major_river;1996;-1;-1;-1;-1;Cairo - Kharibta # Nile
+796;800;major_river;1997;-1;-1;-1;-1;Cairo - Giza # Nile
+796;2001;major_river;1998;-1;-1;-1;-1;Cairo - Faiyum # Nile
+2002;2001;major_river;1998;-1;-1;-1;-1;Akhmim - Faiyum # Nile
+2002;795;major_river;1999;-1;-1;-1;-1;Akhmim - Asyut # Nile
+791;795;major_river;1999;-1;-1;-1;-1;Quena - Asyut # Nile
+791;2003;major_river;1999;-1;-1;-1;-1;Quena - Esna # Nile
+794;2003;major_river;2000;-1;-1;-1;-1;Aswan - Esna # Nile
+165;164;major_river;2010;-1;-1;-1;-1;Cadiz - Niebla # al-Wadi al-Kabir
+165;183;major_river;2011;-1;-1;-1;-1;Cadiz - Aracena # al-Wadi al-Kabir
+182;183;major_river;2011;-1;-1;-1;-1;Seville - Aracena # al-Wadi al-Kabir
+2013;160;major_river;2008;-1;-1;-1;-1;Almada - Seville # Tago
+186;160;major_river;2009;-1;-1;-1;-1;Evora - Lisboa # Tago
+186;2012;major_river;2009;-1;-1;-1;-1;Evora - Egitanea # Tago

--- a/CK2Plus_expanded/map/continent.txt
+++ b/CK2Plus_expanded/map/continent.txt
@@ -1,0 +1,34 @@
+#empty for now, can support this if need be.
+
+region_scandinavia = {
+}
+
+region_british_isles = {
+	regions = {
+		region_britain
+		region_ireland
+		region_isle_of_man
+		region_orkney
+	}
+}
+
+region_iberia = {
+}
+
+region_italy = {
+}
+
+region_france = {
+}
+
+region_north_africa = {
+}
+
+region_levant = {
+}
+
+region_balkans = {
+}
+
+region_eastern_europe = {
+}

--- a/CK2Plus_expanded/map/continent.txt
+++ b/CK2Plus_expanded/map/continent.txt
@@ -4,12 +4,6 @@ region_scandinavia = {
 }
 
 region_british_isles = {
-	regions = {
-		region_britain
-		region_ireland
-		region_isle_of_man
-		region_orkney
-	}
 }
 
 region_iberia = {

--- a/CK2Plus_expanded/map/geographical_region.txt
+++ b/CK2Plus_expanded/map/geographical_region.txt
@@ -1,0 +1,409 @@
+# Geographical regions
+# Regions can be declared with one or more of the following fields:
+#	duchies = { }, takes duchy title names declared in landed_titles.txt
+#	counties = { }, takes county title names declared in landed_titles.txt
+#	provinces = { }, takes province id numbers declared in /history/provinces
+#	regions = { }, a region can also include other regions, however the subregions needs to be declared before the parent region.
+#		E.g. If the region world_europe contains the region world_europe_west then world_europe_west needs to be declared as a region before (i.e. higher up in this file) world_europe.
+
+###########################################################################
+# World Regions
+#	These groups are mutually exclusive on the same tier
+###########################################################################
+
+world_europe_west_brittania = {
+	duchies = {
+		d_northumberland d_lancaster d_york d_norfolk d_bedford d_hereford d_gloucester d_canterbury d_somerset d_gwynedd d_powys d_deheubarth d_cornwall d_the_isles d_galloway d_western_isles d_lothian d_albany d_moray d_ulster d_connacht d_meath d_leinster d_munster d_cumbria d_hampshire d_gwent
+	}
+}
+world_europe_west_germania = {
+	duchies = {
+		d_upper_burgundy d_savoie d_holland d_gelre d_luxembourg d_upper_lorraine d_lower_lorraine d_alsace d_bavaria d_salzburg d_osterreich d_styria d_tyrol d_brunswick d_thuringia d_koln d_franconia d_baden d_swabia d_mecklemburg d_pommerania d_pomeralia d_saxony d_brandenburg d_meissen d_bohemia d_moravia d_thurgau d_raetia d_swiss d_rugen d_bremen d_rhine d_angria d_lausitz d_hesse
+		d_munster_germany d_nordgau d_trier
+	}
+}
+world_europe_west_francia = {
+	duchies = {
+		d_berry d_anjou d_normandy d_orleans d_champagne d_valois d_burgundy d_aquitaine d_toulouse d_gascogne d_poitou d_auvergne d_bourbon d_provence d_dauphine d_brabant d_flanders d_franche_comte d_penthievre d_brittany d_picardie d_loire
+	}
+}
+world_europe_west_iberia = {
+	duchies = {
+		d_castilla d_aragon d_barcelona d_valencia d_mallorca d_navarra d_asturias d_leon d_galicia d_porto d_beja d_algarve d_cordoba d_murcia d_granada d_sevilla d_badajoz d_toledo d_balata
+	}
+}
+world_europe_west = {
+	regions = {
+		world_europe_west_iberia world_europe_west_francia world_europe_west_germania world_europe_west_brittania
+	}
+}
+world_europe_north = {
+	duchies = {
+		#Sweden
+		d_uppland d_ostergotland d_gotland d_vastergotland d_norrland d_bergslagen d_smaland d_tioharad
+		#Norway
+		d_iceland d_orkney d_vestlandet d_ostlandet d_trondelag d_jamtland d_oppland d_agder
+		#Finland minus Estonia
+		d_karelia d_finland  d_ostrobothnia d_savonia
+		#Denmark
+		d_skane d_sjaelland d_slesvig d_holstein
+		#Sápmi
+		d_kola d_finnmark d_sapmi
+	}
+}
+world_europe_south_east = {
+	duchies = {
+		#West ERE
+		d_thrace d_adrianopolis d_thessalonika d_dyrrachion d_epirus d_athens d_achaia d_krete d_cyprus d_vidin d_turnovo d_karvuna d_rashka d_dioclea d_slavonia d_bosnia d_croatia d_dalmatia d_strymon d_ohrid d_cephalonia d_syrmia d_ragusa
+	}
+}
+world_europe_south_italy = {
+	duchies = {
+		d_carinthia d_carniola d_friuli
+		#Italia
+		d_verona d_susa d_lombardia d_genoa d_modena d_ferrara d_toscana d_pisa d_ancona d_spoleto d_latium d_sardinia d_venice d_corsica
+		#Sicily
+		d_benevento d_capua d_apulia d_salerno d_calabria d_sicily d_abruzzo d_amalfi
+	}
+}
+world_europe_south = {
+	regions = {
+		world_europe_south_east world_europe_south_italy
+	}
+}
+world_europe_east = {
+	duchies = {
+		#Wendish minus Pomerania minus Bohemia
+		d_mazovia d_greater_poland d_silesia d_lesser_poland d_kuyavia d_livonia d_prussia d_polotsk d_lithuanians d_yatviags d_courland d_samogitia d_latgale
+		#Russia
+		d_beloozero d_novgorod d_pskov d_rostov d_tver d_yaroslavl d_vladimir d_moskva d_kiev d_galich d_volhynia d_turov d_minsk d_smolensk d_chernigov d_novgorod-seversk d_ryazan d_pereyaslavl d_cherven_cities d_karachev d_novosil d_murom
+		#West Perm
+		d_hlynov d_bjarmia d_ustug d_kargopol d_samoyed
+		#Hungary
+		d_pecs d_esztergom d_nyitra d_ungvar d_pest d_transylvania d_temes
+		#Estonia
+		d_esthonia
+		d_sakala
+		#Wallachia
+		d_wallachia d_oltenia d_moldau d_bessarabia
+	}
+}
+world_asia_minor = {
+	inclusive = yes
+	duchies = {
+		d_nikaea d_samos d_cibyrrhaeot d_anatolia d_charsianon d_armeniacon d_paphlagonia d_trebizond d_armenia_minor d_armenia d_mesopotamia d_edessa d_coloneia d_kartli d_derbent d_abkhazia  d_thracesia d_aegean_islands d_abydos d_kakheti d_tao d_optimatoi d_bucellarian d_cappadocia
+	}
+}
+world_middle_east_jerusalem = {
+	duchies = {
+		#West Syria
+		d_aleppo d_antioch d_tripoli
+		#Jerusalem
+		d_oultrejourdain d_ascalon d_jerusalem d_galilee
+	}
+}
+world_middle_east_arabia = {
+	duchies = {
+		#East Syria
+		d_damascus d_palmyra d_mudar
+		#Arabia
+		d_arabia_petrae d_medina d_sanaa d_oman d_nefoud d_amman d_kermanshah d_tigris d_basra d_baghdad d_mosul d_jazira d_taizz d_hadramut d_samarra
+		#Sinai
+		d_sinai
+	}
+}
+world_india_deccan = {
+	duchies = {
+		#Maharastra
+		d_vidharba d_konkana d_nasikya d_devagiri d_rattapadi
+		#Karnata
+		d_kalyani d_gangavadi d_nulambavadi d_raichur_doab
+		#Tamilakam
+		d_chola_nadu d_pandya_nadu d_chera_nadu d_tondai_nadu
+		#Andhra
+		d_vengi d_udayagiri
+		#Telingana
+		d_warangal d_racakonda
+		#Lanka
+		d_lanka d_sinhala
+	}
+}
+world_india_bengal = {
+	duchies = {
+		#Gondwana
+		d_dahala d_ratanpur
+		#Bengal
+		d_vanga d_varendra d_gauda d_nadia d_suhma
+		#Kamarupa
+		d_kamarupanagara d_para_lauhitya d_sutiya
+		#Orissa
+		d_daksina_kosala d_tosali d_kalinga d_dandakaranya
+		#Bihar
+		d_tirabhukti d_kasi d_jharkand d_magadha
+	}
+}
+world_india_rajastan = {
+	duchies = {
+		#Sindh
+		d_sauvira d_bhakkar
+		#Punjab
+		d_multan d_lahore d_trigarta d_gandhara
+		#Delhi
+		d_kuru d_haritanaka d_mathura d_vodamayutja
+		#Gujarat
+		d_gurjara_mandala d_anartta d_saurashtra d_lata
+		#Rajputana
+		d_maru d_jangladesh d_stravani d_medapata d_ajmer
+		#Malwa
+		d_dadhipadra d_akara_dasarna d_anupa
+		#Kosala
+		d_kanyakubja d_saryupara d_jejakabhukti
+	}
+}
+world_persia = {
+	inclusive = yes
+	duchies = {
+		#Persia minus Mesopotamia
+		d_khorasan d_mazandaran d_esfahan d_kerman d_fars d_hamadan d_tabriz d_azerbaijan d_baluchistan d_sistan d_kabul d_zabulistan d_khiva d_samarkand d_merv d_dihistan d_herat d_balkh d_khuttal d_gilan d_khozistan d_ferghana d_kurdistan d_jibal d_mafaza
+	}
+}
+world_africa_north = {
+	duchies = {
+		d_marrakech d_fes d_tangiers d_tlemcen d_alger d_kabylia d_tunis d_tripolitania d_cyrenaica d_alexandria d_damietta d_cairo d_aswan d_tahert d_sous d_sijilmasa d_mzab d_jerid d_syrte d_fezzan d_adrar d_faiyum d_asyut d_paraetonium
+	}
+}
+world_africa_west = {
+	duchies = {
+		d_songhay d_mali d_ghana d_timbuktu d_bambuk d_yatenga d_tagant d_gurma
+	}
+}
+world_africa_central = {
+	duchies = {
+		d_kebbi d_kanem d_air d_bornu d_hausaland
+	}
+}
+world_africa_east = {
+	duchies = {
+		d_nobatia d_nubia d_sennar d_hayya d_axum d_semien d_gondar d_wag d_gojjam d_damot d_shewa d_afar d_harer d_socotra d_wadai
+	}
+}
+world_africa = {
+	regions = {
+		world_africa_north world_africa_west world_africa_east world_africa_central
+	}
+}
+world_steppe_tarim = {
+	duchies = {
+		d_kashgar d_khotan d_karashar d_kumul
+	}
+}
+world_steppe_west = {
+	duchies = {
+		#East Perm
+		d_perm d_yugra d_bashkirs
+		#Tartaria
+		d_itil d_sarkel d_yaik d_sibir d_kipchak d_kimak d_maris d_bulgar d_kazan d_cheremisa d_mordvins d_cherson d_crimea d_alania d_azov d_turkestan d_syr_darya d_wild_fields d_usturt d_emba d_caspian_steppe d_bandja d_atyrau d_aqtobe d_sakmara d_tobol d_ishim d_ubagan d_om d_vasyugan d_kazakh d_turgay
+		# Ural & Nenetsia
+		d_komi d_zavarot d_pechora d_zyriane d_votyaki d_ural
+	}
+	counties = {
+		c_kimak
+	}
+}
+world_steppe_east = {
+	duchies = {
+		d_zhetysu d_chuy d_kirghiz d_altay d_otuken d_khangai d_ikh_bogd d_ili d_beshbaliq d_abakan d_uvs d_kara_khorum d_baygal d_gobi_altay d_barkul d_juyan d_tarbagatai d_ob d_jiuquan
+	}
+	counties = {
+		c_kirghiz
+	}
+}
+world_steppe = {
+	inclusive = yes
+	regions = {
+		world_steppe_west world_steppe_east world_steppe_tarim
+	}
+}
+world_europe = {
+	inclusive = yes
+	regions = {
+		world_europe_west world_europe_south world_europe_east world_europe_north
+	}
+}
+world_middle_east = {
+	inclusive = yes
+	regions = {
+		world_middle_east_arabia world_middle_east_jerusalem
+	}
+}
+world_india = {
+	inclusive = yes
+	regions = {
+		world_india_deccan world_india_bengal world_india_rajastan
+	}
+}
+
+world_himalayas = {
+	inclusive = yes
+	duchies = {
+		d_lhasa d_yarlung d_shigatse d_nagchu d_sumparu d_bhutan d_purang d_ngari d_ladakh d_dege d_qamdo d_nyingchi d_kathmandu d_gorkha d_kashmir d_pamir d_uttaranchal d_qinghai d_nagormo d_nangqen
+	}
+}
+
+###########################################################################
+# Custom Regions
+###########################################################################
+
+custom_eastern_baltic = {
+	duchies = {
+		#Finland
+		d_karelia d_finland d_kola d_esthonia d_sakala d_ostrobothnia d_savonia
+		#Lithuania
+		d_livonia d_prussia d_polotsk d_lithuanians d_courland d_yatviags d_samogitia d_latgale
+	}
+}
+custom_russia = {
+	duchies = {
+		d_beloozero d_novgorod d_pskov d_rostov d_tver d_yaroslavl d_vladimir d_moskva d_kiev d_galich d_volhynia d_turov d_minsk d_smolensk d_chernigov d_novgorod-seversk d_ryazan d_pereyaslavl d_cherven_cities d_karachev d_novosil d_murom
+	}
+}
+custom_frisia = {
+	duchies = {
+		d_holland d_gelre d_brabant d_flanders
+	}
+}
+custom_england = {
+	duchies = {
+		d_northumberland d_lancaster d_york d_norfolk d_bedford d_hereford d_gloucester d_canterbury d_somerset
+	}
+}
+custom_castillian = {
+	duchies = {
+		d_castilla d_asturias d_leon
+	}
+}
+custom_catalan = {
+	duchies = {
+		d_aragon d_barcelona d_valencia d_mallorca
+	}
+}
+custom_andalusian = {
+	duchies = {
+		d_cordoba d_murcia d_granada d_sevilla d_badajoz d_toledo
+	}
+}
+custom_portuguese = {
+	duchies = {
+		d_galicia d_porto d_beja d_algarve
+	}
+}
+custom_swedish = {
+	duchies = {
+		d_uppland d_ostergotland d_gotland d_vastergotland d_norrland d_bergslagen d_smaland d_tioharad d_sapmi
+	}
+}
+custom_danish = {
+	duchies = {
+		d_skane d_sjaelland d_slesvig d_holstein
+	}
+}
+custom_norwegian = {
+	duchies = {
+		d_iceland d_orkney d_vestlandet d_ostlandet d_trondelag d_jamtland d_finnmark
+	}
+}
+custom_scotland = {
+	duchies = {
+		d_the_isles d_galloway d_western_isles d_lothian d_albany d_moray
+	}
+}
+custom_historical_plague_free_zone = {
+	duchies = {
+		d_lombardia d_lesser_poland d_kuyavia d_mazovia d_yatviags d_turov d_volhynia d_iceland d_cherven_cities d_minsk
+	}
+	counties = {
+		c_valais c_schwyz c_alto_aragon c_urgell c_bearn c_faereyar c_lepiel c_orsha c_armagnac c_foix c_chur c_yatvyagi c_aukshayts c_kaliskie c_gnieznienskie
+	}
+}
+custom_eastern_edge_of_map = {
+	counties = {
+		c_jiuquan c_fuqi c_delingha c_dege c_ejin c_samatata c_markam c_lingtsang c_gurvan_saikhan c_delgerkhangai c_tuul c_chikoi c_khilok c_uda
+	}
+}
+custom_chinese_invasion_target_region = {
+	duchies = {
+		d_pandya_nadu d_chola_nadu d_tondai_nadu d_chera_nadu d_lanka d_sinhala d_vengi d_udayagiri
+	}
+	regions = {
+		world_india_bengal world_steppe_tarim world_steppe_east world_himalayas
+	}
+}
+
+custom_eastern_access = {
+	duchies = {
+		d_kumul d_karashar d_kashgar d_khotan d_ferghana d_samarkand d_syr_darya d_kirghiz d_juyan d_barkul d_beshbaliq
+	}
+	regions = {
+		world_himalayas
+	}
+}
+
+custom_leon = {
+	duchies = {
+		d_leon d_asturias
+	}
+}
+
+custom_galicia = {
+	duchies = {
+		d_galicia d_porto
+	}
+}
+
+custom_beja = {
+	duchies = {
+		d_beja d_algarve d_balata
+	}
+}
+
+custom_granada = {
+	duchies = {
+		d_granada d_sevilla
+	}
+}
+
+custom_castille = {
+	duchies = {
+		d_castilla d_toledo
+	}
+}
+
+custom_aragon = {
+	duchies = {
+		d_aragon d_barcelona
+	}
+}
+
+custom_cordoba = {
+	duchies = {
+		d_cordoba d_badajoz
+	}
+}
+
+custom_valencia = {
+	duchies = {
+		d_valencia d_murcia
+	}
+}
+
+custom_navarra = {
+	duchies = {
+		d_navarra
+	}
+}
+
+custom_balearic = {
+	duchies = {
+		d_mallorca
+	}
+}

--- a/CK2Plus_expanded/map/geographical_region.txt
+++ b/CK2Plus_expanded/map/geographical_region.txt
@@ -242,7 +242,6 @@ world_india = {
 		world_india_deccan world_india_bengal world_india_rajastan
 	}
 }
-
 world_himalayas = {
 	inclusive = yes
 	duchies = {
@@ -338,7 +337,6 @@ custom_chinese_invasion_target_region = {
 		world_india_bengal world_steppe_tarim world_steppe_east world_himalayas
 	}
 }
-
 custom_eastern_access = {
 	duchies = {
 		d_kumul d_karashar d_kashgar d_khotan d_ferghana d_samarkand d_syr_darya d_kirghiz d_juyan d_barkul d_beshbaliq
@@ -347,61 +345,51 @@ custom_eastern_access = {
 		world_himalayas
 	}
 }
-
 custom_leon = {
 	duchies = {
 		d_leon d_asturias
 	}
 }
-
 custom_galicia = {
 	duchies = {
 		d_galicia d_porto
 	}
 }
-
 custom_beja = {
 	duchies = {
 		d_beja d_algarve d_balata
 	}
 }
-
 custom_granada = {
 	duchies = {
 		d_granada d_sevilla
 	}
 }
-
 custom_castille = {
 	duchies = {
 		d_castilla d_toledo
 	}
 }
-
 custom_aragon = {
 	duchies = {
 		d_aragon d_barcelona
 	}
 }
-
 custom_cordoba = {
 	duchies = {
 		d_cordoba d_badajoz
 	}
 }
-
 custom_valencia = {
 	duchies = {
 		d_valencia d_murcia
 	}
 }
-
 custom_navarra = {
 	duchies = {
 		d_navarra
 	}
 }
-
 custom_balearic = {
 	duchies = {
 		d_mallorca

--- a/CK2Plus_expanded/map/island_region.txt
+++ b/CK2Plus_expanded/map/island_region.txt
@@ -1,0 +1,90 @@
+# Island regions - no land path from the continent
+# The AI needs these to optimize path finding
+#
+# NOTE: do not add any regions here that are NOT islands
+
+# Regions can be declared with one or more of the following fields:
+#	duchies = { }, takes duchy title names declared in landed_titles.txt
+#	counties = { }, takes county title names declared in landed_titles.txt
+#	provinces = { }, takes province id numbers declared in /history/provinces
+#	regions = { }, a region can also include other regions, however the subregions needs to be declared before the parent region.
+#		E.g. If the region world_europe contains the region world_europe_west then world_europe_west needs to be declared as a region before (i.e. higher up in this file) world_europe.
+
+region_iceland = {
+	provinces = { 1 2 1616 1617 }
+}
+
+region_faereyar = {
+	provinces = { 33 }
+}
+
+region_shetland = {
+	provinces = { 34 }
+}
+
+region_britain = {
+	provinces = {
+		17 18 19 20 21
+		22 23 24 25 26 27 28 29 30 31 32 35 37 38 39
+		40 41 42 43 44 45 46 47 48 49 50 51 52 53 55
+		56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71
+		72 73 1939 1940 1941 1942 1943 1944 1945 1946 1947
+		1948 1949 1950
+	}
+}
+
+region_baleares = {
+	provinces = { 826 827  }
+}
+
+region_sardinia_corsica = {
+	provinces = { 324 325 326 1560 1574 1576 1577 }
+}
+
+region_malta = {
+	provinces = { 812 }
+}
+
+region_crete = {
+	provinces = { 479 480 }
+}
+
+region_cyprus = {
+	provinces = { 756 757 }
+}
+
+region_socotra = {
+	provinces = { 1369 }
+}
+
+region_maldives = {
+	provinces = { 1360 }
+}
+
+region_canarias = {
+	provinces = { 849 }
+}
+
+region_venice = {
+	provinces = { 356 }
+}
+
+region_kolguyev = {
+	provinces = { 1829 }
+}
+
+# PLUS ADDED
+
+region_ireland = {
+	provinces = {
+		3 4 5 7 8 9 10 11 12 13 14 15 16 1938 1951 1952 1953 1954 1955
+	}
+}
+
+region_isle_of_man = {
+	provinces = { 54 }
+}
+
+region_orkney = {
+	provinces = { 36 }
+}


### PR DESCRIPTION
This makes shipping more important by removing all but one sea connection (more can be added back in later if necessary for balance). This should prevent the AI from conquering things they'd normally need boats for before they have access to boats.