### PR TITLE
Babies are more efficiently made

### DIFF
--- a/CK2Plus/common/on_actions/000_CK2Plus_on_actions_maintenance.txt
+++ b/CK2Plus/common/on_actions/000_CK2Plus_on_actions_maintenance.txt
@@ -17,9 +17,10 @@ on_yearly_childhood_pulse = {
 	}
 }
 
-# TEMPORARY (?) PATCH AGAINST BUG (NOTE):
-on_chronicle_start = {
+# Proper solution for newly created characters (catches both events and hardcoded):
+on_host_change = {
 	events = {
-		PlusMaintenance.004		# This whole event should later be removed, but atm it is necessary because of a vanilla bug/problem
+		# NOTE: Currently untested whether it actually works! Test that at some point.
+		PlusMaintenance.004		# Applies any CK2+ stuff we want to see on new characters, including baby faces (if game rule)
 	}
 }

--- a/CK2Plus/events/000_CK2Plus_maintenance_events.txt
+++ b/CK2Plus/events/000_CK2Plus_maintenance_events.txt
@@ -150,50 +150,26 @@ character_event = {
 	}
 }
 
-# TEMPORARY (?) PATCH AGAINST BUG (NOTE):
-
-# This whole event should later be removed, but atm it is necessary because of a vanilla bug/problem
+# This event is fired from on-action for any newly created character, including by hardcoded means
 character_event = {
 	id = PlusMaintenance.004
 
 	hide_window = yes
 
-	is_triggered_only = yes		# from on_chronicle_startup - only for the player
+	is_triggered_only = yes		# from on_host_change - for any character that changes hosts
 
 	trigger = {
-		# Now, check if "generate families" vanilla game rule is active, because that is screwing with trait assignment (fires earlier than the regular event)
-		NOT = {	# is not disabled (easier than checking for both "on" options)
-			has_game_rule = {
-				name = generate_families
-				value = off
-			}
+		# Important: Check if charcter is newly created
+		FROM = {	# the previous host
+			character = no	# If old host is undefined, the Root character is newly created!
 		}
 	}
 
 	immediate = {
-		# this just waits a day, and then fires the actual fixing event
+		# Apply any event here that should affect a newly created character
 		character_event = {
-			id = PlusMaintenance.005
-			days = 1	# just wait a day or so, then the game generated new babys should exist
+			id = PlusMaintenance.003	# Apply baby traits (and portraits if gamerule)
 		}
 	}
-}
-
-# This whole event should later be removed, but atm it is necessary because of a vanilla bug/problem
-character_event = {
-	id = PlusMaintenance.005
-
-	hide_window = yes
-
-	is_triggered_only = yes		# from previous event
-
-	immediate = {
-		any_independent_ruler = {
-			any_realm_character = {
-				limit = { age < 2 }
-				# Fire event to assign traits again, so that all characters that are babies at gamestart get it.
-				character_event = { id = PlusMaintenance.003 }
-			}
-		}
-	}
+	#NOTE: This whole thing is currently untested, need to check if it actually works as advertised by vanilla patch notes...
 }

--- a/CK2Plus/events/game_rule_events.txt
+++ b/CK2Plus/events/game_rule_events.txt
@@ -7924,5 +7924,15 @@ character_event = { # Generate 'Fake Family' for characters without any
 			}
 		}
 		recalc_succession = yes
+		
+		# CK2Plus: Add baby trait/portrait
+		any_child = {
+			limit = {
+				age < 2
+			}
+			character_event = {
+				id = PlusMaintenance.003
+			}
+		}
 	}
 }

--- a/CK2Plus/events/game_rule_events.txt
+++ b/CK2Plus/events/game_rule_events.txt
@@ -1,0 +1,7928 @@
+####################
+# Game Rule Events #
+####################
+# Alexander Oltner
+# Mathilda Bjarnehed
+
+namespace = GR
+
+# Remove Titles without De Jure land
+character_event = {
+	id = GR.1
+	desc = EVTDESC_GR_1
+	picture = GFX_evt_throne_room
+
+	is_triggered_only = yes
+
+	only_playable = yes
+	war = no
+
+	trigger = {
+		is_merchant_republic = no
+		any_demesne_title = {
+			higher_tier_than = COUNT
+			is_titular = no
+			is_landless_type_title = no
+			NOR = {
+				title = k_papal_state
+				title = k_orthodox
+			}
+			NOT = {
+				ROOT = {
+					any_realm_title = {
+						tier = COUNT
+						any_dejure_liege = { title = PREVPREVPREV }
+					}
+				}
+			}
+		}
+		has_game_rule = {
+			name = de_jure_requirement
+			value = required
+		}
+	}
+
+	immediate = {
+		random_demesne_title = {
+			limit = {
+				higher_tier_than = COUNT
+				is_titular = no
+				is_landless_type_title = no
+				NOR = {
+					title = k_papal_state
+					title = k_orthodox
+				}
+				NOT = {
+					ROOT = {
+						any_realm_title = {
+							tier = COUNT
+							any_dejure_liege = { title = PREVPREVPREV }
+						}
+					}
+				}
+			}
+			save_event_target_as = title_to_destroy
+		}
+	}
+
+	option = {
+		name = EVTOPTA_GR_1
+		event_target:title_to_destroy = {
+			destroy_landed_title = THIS
+			add_claim = ROOT
+		}
+	}
+}
+
+# Nomad Realm Instability
+character_event = {
+	id = GR.10
+	hide_window = yes
+
+	only_playable = yes
+
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "Horse Lords"
+		independent = yes
+		is_nomadic = yes
+		NOT = {
+			has_game_rule = {
+				name = nomad_stability
+				value = stable
+			}
+		}
+	}
+
+	immediate = {
+		current_heir = {
+		  save_event_target_as = nomadic_heir
+		}
+		any_vassal = {
+			character_event = { id = GR.11 }
+		}
+	}
+}
+
+character_event = {
+	id = GR.11
+	desc = EVTDESC_GR_11
+	picture = GFX_evt_horsemanship
+
+	only_playable = yes
+	capable_only = yes
+	prisoner = no
+	min_age = 16
+
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "Horse Lords"
+		liege = {
+			independent = yes
+			is_nomadic = yes
+			in_revolt = no
+		}
+		in_revolt = no
+		independent = no
+	}
+
+	option = {
+		name = EVTOPTA_GR_11 # Remain a vassal
+		ai_chance = {
+			factor = 100
+			modifier = {
+				factor = 2
+				opinion = {
+					who = FROM
+					value = 25
+				}
+			}
+			modifier = {
+				factor = 2
+				opinion = {
+					who = FROM
+					value = 50
+				}
+			}
+			modifier = {
+				factor = 2
+				opinion = {
+					who = FROM
+					value = 75
+				}
+			}
+			modifier = {
+				factor = 2
+				opinion = {
+					who = FROM
+					value = 100
+				}
+			}
+			modifier = {
+				factor = 2
+				liege = {
+					NOT = {
+						realm_size = 50
+					}
+				}
+			}
+			modifier = {
+				factor = 3
+				is_nomadic = yes
+			}
+			modifier = {
+				factor = 10
+				liege = {
+					has_landed_title = e_mongol_empire
+				}
+			}
+			modifier = {
+				factor = 4
+				trait = content
+			}
+		}
+	}
+	option = {
+		name = EVTOPTB_GR_11 # Go independent
+
+		ai_chance = {
+			factor = 50
+			modifier = {
+				factor = 0
+				clan = yes
+				OR = {
+					has_blood_oath_with = FROM
+					is_friend = FROM
+				}
+			}
+			modifier = {
+				factor = 2
+				clan = yes
+				OR = {
+					has_feud_with = FROM
+					is_rival = FROM
+				}
+			}
+			modifier = {
+				factor = 2
+				NOT = {
+					opinion = {
+						who = FROM
+						value = -25
+					}
+				}
+			}
+			modifier = {
+				factor = 2
+				NOT = {
+					opinion = {
+						who = FROM
+						value = -50
+					}
+				}
+			}
+			modifier = {
+				factor = 2
+				NOT = {
+					opinion = {
+						who = FROM
+						value = -75
+					}
+				}
+			}
+			modifier = {
+				factor = 2
+				NOT = {
+					opinion = {
+						who = FROM
+						value = -100
+					}
+				}
+			}
+			modifier = {
+				factor = 2
+				trait = ambitious
+			}
+		}
+
+		hidden_tooltip = {
+			event_target:nomadic_heir = { character_event = { id = GR.12 days = 1 } }
+		}
+
+		if = {
+			limit = {
+				is_nomadic = yes
+			}
+			any_demesne_title = {
+				limit = {
+					tier = count
+				}
+				add_claim = event_target:nomadic_heir
+			}
+		}
+
+		if = {
+			limit = {
+				is_nomadic = no
+			}
+			reverse_opinion = {
+				who = event_target:nomadic_heir
+				modifier = declared_independence_nomad
+				years = 50
+			}
+			hidden_tooltip = {
+				any_courtier_or_vassal = {
+					limit = {
+						dynasty = ROOT
+					}
+					reverse_opinion = {
+						who = event_target:nomadic_heir
+						modifier = declared_independence_nomad
+						years = 50
+					}
+				}
+			}
+		}
+
+		liege = {
+			any_vassal = {
+				limit = {
+					in_revolt = yes
+					any_war = {
+						defender = { character = ROOT }
+						attacker = {
+							character = THIS
+						}
+					}
+				}
+				set_defacto_liege = THIS
+			}
+		}
+
+		set_defacto_liege = THIS
+	}
+}
+
+# The liege is notified of the independence
+character_event = {
+	id = GR.12
+	desc = EVTDESC_GR_12
+	picture = GFX_evt_emissary
+
+	is_triggered_only = yes
+
+	notification = yes
+
+	option = {
+		name = EVTOPTA_GR_12
+	}
+
+}
+
+#True cognatic for gender quality rule
+character_event = {
+	id = GR.13
+	hide_window = yes
+
+	ai = no
+	only_playable = yes
+
+	is_triggered_only = yes
+
+	trigger = {
+		has_game_rule = {
+			name = gender
+			value = all
+		}
+		is_multiplayer_host_character = yes
+		is_save_game = no
+	}
+
+	immediate = {
+		any_title = {
+			limit = { owner = { is_republic = no } }
+			add_law = {
+				law = true_cognatic_succession
+				cooldown = no
+				opinion_effect = no
+			}
+		}
+	}
+}
+
+character_event = { # Border Gore cleanser (Limited)
+	id = GR.14
+
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	only_independent = yes
+	only_playable = yes
+
+	trigger = {
+		holy_order = no # Holy orders are intended to hold baronies all over the place
+		NOT = {
+			has_landed_title = k_papal_state # The Pope should also be able to hold baronies all over the place
+		}
+		has_game_rule = {
+			name = exclave_purge
+			value = limited
+		}
+		capital_scope = {
+			any_disconnected_province = {
+				sub_realm = no
+				NOR = {
+					de_jure_liege_or_above = ROOT
+					is_connected_to = {
+						sub_realm = no
+						target = realm_capital
+						land_gap = yes
+						naval_distance = yes
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+		if = { # AI characters at war will get this event later
+			limit = {
+				ai = yes
+				war = yes
+				player_heir = {
+					ai = yes
+				}
+			}
+			player_heir = {
+				set_character_flag = delayed_cleanse_ai
+			}
+			break = yes
+		}
+		else_if = { # Players who are at war during succession do not need the extra stress element of getting their realm cleansed
+			limit = {
+				war = yes
+				ai = no
+			}
+			break = yes
+		}
+		# Counties are set free first, to avoid releasing vassals of vassals we first loop through provinces held by Kings, then Dukes, and finally Counts
+		while = { # Eliminate County exclaves (Kings)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = yes
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = yes
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (Dukes)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = yes
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = yes
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (All others)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = yes
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = yes
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Set Peasant Leaders free in 'chunks'
+			count = 100
+			limit = {
+				any_realm_province = {
+					has_province_flag = peasant_cleansed
+				}
+			}
+			random_realm_province = {
+				limit = {
+					has_province_flag = peasant_cleansed
+				}
+				create_character = {
+					random_traits = yes
+					dynasty = culture
+					religion = THIS
+					culture = THIS
+					female = 5
+					age = 25
+					trait = peasant_leader
+				}
+				new_character = {
+					save_event_target_as = new_holder
+				}
+				county = {
+					usurp_title = { target = event_target:new_holder type = revolt }
+				}
+				event_target:new_holder = {
+					save_event_target_as = text_target
+					any_liege = {
+						character_event = { id = GR.20 } # Notify peasant independence
+					}
+				}
+				holder_scope = {
+					set_defacto_liege = event_target:new_holder
+				}
+				log = "[This.GetName] is being set independent under a peasant leader ([new_holder.GetBestName])"
+				if = { # Special case for Nomads
+					limit = {
+						event_target:new_holder = {
+							is_nomadic = yes
+						}
+						any_province_holding = {
+							OR = {
+								holding_type = city
+								holding_type = temple
+								holding_type = castle
+								holding_type = tribal
+							}
+						}
+					}
+					event_target:new_holder = {
+						set_government_type = tribal_government
+					}
+					if = {
+						limit = {
+							any_province_holding = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+						}
+						random_province_holding = {
+							limit = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+							destroy_settlement = THIS
+						}
+					}
+					log = "The holder is nomadic, but the county is unsuitable for nomadic life - reverting to tribalism"
+				}
+				any_connected_province = {
+					sub_realm = ROOT
+					limit = {
+						has_province_flag = peasant_cleansed
+					}
+					county = {
+						usurp_title = { target = event_target:new_holder type = revolt }
+						log = "The [This.GetName] County is being assigned to [new_holder.GetBestName] as it is directly connected to their capital of [new_holder.Capital.GetName]"
+					}
+				}
+				event_target:new_holder = {
+					wealth = 300
+					prestige = 300
+					piety = 200
+					any_realm_province = {
+						clr_province_flag = peasant_cleansed
+					}
+				}
+			}
+		}
+		while = { # Eliminate Barony exclaves
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = ROOT
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = ROOT
+					limit = {
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "Baronies in [This.GetName] considered for cleansing"
+
+					county = {
+						save_event_target_as = barony_origin_province
+					}
+
+					any_province_holding = {
+						limit = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+							NOR = {
+								holding_type = nomad
+								holding_type = family_palace
+							}
+						}
+						holder_scope = {
+							save_event_target_as = owner_independent
+							liege = {
+								save_event_target_as = owner_liege
+							}
+						}
+						log = "[This.GetName] is considered for cleansing"
+						if = { # If the holder is you, set the barony free under a peasant
+							limit = {
+								holder_scope = {
+									character = ROOT
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+						else_if = { # Characters that only hold this barony are set free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										demesne_size = 2
+										num_of_vassals = 1
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they only held one holding"
+						}
+						else_if = { # If the holder has no holdings that connect to the realm capital, set them free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										any_demesne_title = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												land_gap = yes
+												naval_distance = yes
+											}
+										}
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they held no land connected to the liege's realm"
+						}
+						else_if = { # If the holder is higher tier than baron, but doesn't hold ANY count titles, transfer all vassals/baronies in the capital area to their liege and set them independent
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									higher_tier_than = BARON
+									NOT = {
+										any_demesne_title = {
+											tier = COUNT
+										}
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+							holder_scope = {
+								any_vassal = {
+									limit = {
+										any_realm_province = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												land_gap = yes
+												naval_distance = yes
+											}
+										}
+									}
+									set_defacto_liege = event_target:owner_liege
+								}
+								any_demesne_title = {
+									limit = {
+										tier = BARON
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											land_gap = yes
+											naval_distance = yes
+										}
+									}
+									grant_title = ROOT
+								}
+								event_target:new_holder = {
+									save_event_target_as = text_target
+									character_event = { id = GR.22 } # Notify player going independent
+									any_liege = {
+										character_event = { id = GR.19 } # Notify independence
+									}
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal of higher tier than Baron with vassals, all their vassals in the capital area were reassigned to liege, and then the holder was set independent"
+						}
+						else_if = { # If the holder has land that connects to the liege's capital, set the baronies free under peasants
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal, and was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+character_event = { # Border Gore cleanser (Significant)
+	id = GR.15
+
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	only_independent = yes
+	only_playable = yes
+
+	trigger = {
+		holy_order = no # Holy orders are intended to hold baronies all over the place
+		NOT = {
+			has_landed_title = k_papal_state # The Pope should also be able to hold baronies all over the place
+		}
+		has_game_rule = {
+			name = exclave_purge
+			value = significant
+		}
+		capital_scope = {
+			any_disconnected_province = {
+				sub_realm = no
+				NOR = {
+					de_jure_liege_or_above = ROOT
+					is_connected_to = {
+						sub_realm = no
+						target = realm_capital
+						#land_gap = yes
+						naval_distance = yes
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+		if = { # AI characters at war will get this event later
+			limit = {
+				ai = yes
+				war = yes
+				player_heir = {
+					ai = yes
+				}
+			}
+			player_heir = {
+				set_character_flag = delayed_cleanse_ai
+			}
+			break = yes
+		}
+		else_if = { # Players who are at war during succession do not need the extra stress element of getting their realm cleansed
+			limit = {
+				war = yes
+				ai = no
+			}
+			break = yes
+		}
+		# Counties are set free first, to avoid releasing vassals of vassals we first loop through provinces held by Kings, then Dukes, and finally Counts
+		while = { # Eliminate County exclaves (Kings)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = yes
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = yes
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (Dukes)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = yes
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = yes
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (All others)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = yes
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = yes
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Set Peasant Leaders free in 'chunks'
+			count = 100
+			limit = {
+				any_realm_province = {
+					has_province_flag = peasant_cleansed
+				}
+			}
+			random_realm_province = {
+				limit = {
+					has_province_flag = peasant_cleansed
+				}
+				create_character = {
+					random_traits = yes
+					dynasty = culture
+					religion = THIS
+					culture = THIS
+					female = 5
+					age = 25
+					trait = peasant_leader
+				}
+				new_character = {
+					save_event_target_as = new_holder
+				}
+				county = {
+					usurp_title = { target = event_target:new_holder type = revolt }
+				}
+				event_target:new_holder = {
+					save_event_target_as = text_target
+					any_liege = {
+						character_event = { id = GR.20 } # Notify peasant independence
+					}
+				}
+				holder_scope = {
+					set_defacto_liege = event_target:new_holder
+				}
+				log = "[This.GetName] is being set independent under a peasant leader ([new_holder.GetBestName])"
+				if = { # Special case for Nomads
+					limit = {
+						event_target:new_holder = {
+							is_nomadic = yes
+						}
+						any_province_holding = {
+							OR = {
+								holding_type = city
+								holding_type = temple
+								holding_type = castle
+								holding_type = tribal
+							}
+						}
+					}
+					event_target:new_holder = {
+						set_government_type = tribal_government
+					}
+					if = {
+						limit = {
+							any_province_holding = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+						}
+						random_province_holding = {
+							limit = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+							destroy_settlement = THIS
+						}
+					}
+					log = "The holder is nomadic, but the county is unsuitable for nomadic life - reverting to tribalism"
+				}
+				any_connected_province = {
+					sub_realm = ROOT
+					limit = {
+						has_province_flag = peasant_cleansed
+					}
+					county = {
+						usurp_title = { target = event_target:new_holder type = revolt }
+						log = "The [This.GetName] County is being assigned to [new_holder.GetBestName] as it is directly connected to their capital of [new_holder.Capital.GetName]"
+					}
+				}
+				event_target:new_holder = {
+					wealth = 300
+					prestige = 300
+					piety = 200
+					any_realm_province = {
+						clr_province_flag = peasant_cleansed
+					}
+				}
+			}
+		}
+		while = { # Eliminate Barony exclaves
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = ROOT
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = ROOT
+					limit = {
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = yes
+							}
+						}
+					}
+					log = "Baronies in [This.GetName] considered for cleansing"
+
+					county = {
+						save_event_target_as = barony_origin_province
+					}
+
+					any_province_holding = {
+						limit = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+							NOR = {
+								holding_type = nomad
+								holding_type = family_palace
+							}
+						}
+						holder_scope = {
+							save_event_target_as = owner_independent
+							liege = {
+								save_event_target_as = owner_liege
+							}
+						}
+						log = "[This.GetName] is considered for cleansing"
+						if = { # If the holder is you, set the barony free under a peasant
+							limit = {
+								holder_scope = {
+									character = ROOT
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+						else_if = { # Characters that only hold this barony are set free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										demesne_size = 2
+										num_of_vassals = 1
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they only held one holding"
+						}
+						else_if = { # If the holder has no holdings that connect to the realm capital, set them free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										any_demesne_title = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												#land_gap = yes
+												naval_distance = yes
+											}
+										}
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they held no land connected to the liege's realm"
+						}
+						else_if = { # If the holder is higher tier than baron, but doesn't hold ANY count titles, transfer all vassals/baronies in the capital area to their liege and set them independent
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									higher_tier_than = BARON
+									NOT = {
+										any_demesne_title = {
+											tier = COUNT
+										}
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+							holder_scope = {
+								any_vassal = {
+									limit = {
+										any_realm_province = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												#land_gap = yes
+												naval_distance = yes
+											}
+										}
+									}
+									set_defacto_liege = event_target:owner_liege
+								}
+								any_demesne_title = {
+									limit = {
+										tier = BARON
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = yes
+										}
+									}
+									grant_title = ROOT
+								}
+								event_target:new_holder = {
+									save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+									any_liege = {
+										character_event = { id = GR.19 } # Notify independence
+									}
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal of higher tier than Baron with vassals, all their vassals in the capital area were reassigned to liege, and then the holder was set independent"
+						}
+						else_if = { # If the holder has land that connects to the liege's capital, set the baronies free under peasants
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = yes
+										}
+									}
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal, and was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+character_event = { # Border Gore cleanser (Harsh)
+	id = GR.16
+
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	only_independent = yes
+	only_playable = yes
+
+	trigger = {
+		holy_order = no # Holy orders are intended to hold baronies all over the place
+		NOT = {
+			has_landed_title = k_papal_state # The Pope should also be able to hold baronies all over the place
+		}
+		has_game_rule = {
+			name = exclave_purge
+			value = harsh
+		}
+		capital_scope = {
+			any_disconnected_province = {
+				sub_realm = no
+				NOR = {
+					de_jure_liege_or_above = ROOT
+					is_connected_to = {
+						sub_realm = no
+						target = realm_capital
+						#land_gap = yes
+						naval_distance = 1000
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+		if = { # AI characters at war will get this event later
+			limit = {
+				ai = yes
+				war = yes
+				player_heir = {
+					ai = yes
+				}
+			}
+			player_heir = {
+				set_character_flag = delayed_cleanse_ai
+			}
+			break = yes
+		}
+		else_if = { # Players who are at war during succession do not need the extra stress element of getting their realm cleansed
+			limit = {
+				war = yes
+				ai = no
+			}
+			break = yes
+		}
+		# Counties are set free first, to avoid releasing vassals of vassals we first loop through provinces held by Kings, then Dukes, and finally Counts
+		while = { # Eliminate County exclaves (Kings)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (Dukes)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (All others)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Set Peasant Leaders free in 'chunks'
+			count = 100
+			limit = {
+				any_realm_province = {
+					has_province_flag = peasant_cleansed
+				}
+			}
+			random_realm_province = {
+				limit = {
+					has_province_flag = peasant_cleansed
+				}
+				create_character = {
+					random_traits = yes
+					dynasty = culture
+					religion = THIS
+					culture = THIS
+					female = 5
+					age = 25
+					trait = peasant_leader
+				}
+				new_character = {
+					save_event_target_as = new_holder
+				}
+				county = {
+					usurp_title = { target = event_target:new_holder type = revolt }
+				}
+				event_target:new_holder = {
+					save_event_target_as = text_target
+					any_liege = {
+						character_event = { id = GR.20 } # Notify peasant independence
+					}
+				}
+				holder_scope = {
+					set_defacto_liege = event_target:new_holder
+				}
+				log = "[This.GetName] is being set independent under a peasant leader ([new_holder.GetBestName])"
+				if = { # Special case for Nomads
+					limit = {
+						event_target:new_holder = {
+							is_nomadic = yes
+						}
+						any_province_holding = {
+							OR = {
+								holding_type = city
+								holding_type = temple
+								holding_type = castle
+								holding_type = tribal
+							}
+						}
+					}
+					event_target:new_holder = {
+						set_government_type = tribal_government
+					}
+					if = {
+						limit = {
+							any_province_holding = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+						}
+						random_province_holding = {
+							limit = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+							destroy_settlement = THIS
+						}
+					}
+					log = "The holder is nomadic, but the county is unsuitable for nomadic life - reverting to tribalism"
+				}
+				any_connected_province = {
+					sub_realm = ROOT
+					limit = {
+						has_province_flag = peasant_cleansed
+					}
+					county = {
+						usurp_title = { target = event_target:new_holder type = revolt }
+						log = "The [This.GetName] County is being assigned to [new_holder.GetBestName] as it is directly connected to their capital of [new_holder.Capital.GetName]"
+					}
+				}
+				event_target:new_holder = {
+					wealth = 300
+					prestige = 300
+					piety = 200
+					any_realm_province = {
+						clr_province_flag = peasant_cleansed
+					}
+				}
+			}
+		}
+		while = { # Eliminate Barony exclaves
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = ROOT
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = ROOT
+					limit = {
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "Baronies in [This.GetName] considered for cleansing"
+
+					county = {
+						save_event_target_as = barony_origin_province
+					}
+
+					any_province_holding = {
+						limit = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+							NOR = {
+								holding_type = nomad
+								holding_type = family_palace
+							}
+						}
+						holder_scope = {
+							save_event_target_as = owner_independent
+							liege = {
+								save_event_target_as = owner_liege
+							}
+						}
+						log = "[This.GetName] is considered for cleansing"
+						if = { # If the holder is you, set the barony free under a peasant
+							limit = {
+								holder_scope = {
+									character = ROOT
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+						else_if = { # Characters that only hold this barony are set free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										demesne_size = 2
+										num_of_vassals = 1
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they only held one holding"
+						}
+						else_if = { # If the holder has no holdings that connect to the realm capital, set them free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										any_demesne_title = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												#land_gap = yes
+												naval_distance = 1000
+											}
+										}
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they held no land connected to the liege's realm"
+						}
+						else_if = { # If the holder is higher tier than baron, but doesn't hold ANY count titles, transfer all vassals/baronies in the capital area to their liege and set them independent
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									higher_tier_than = BARON
+									NOT = {
+										any_demesne_title = {
+											tier = COUNT
+										}
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+							holder_scope = {
+								any_vassal = {
+									limit = {
+										any_realm_province = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												#land_gap = yes
+												naval_distance = 1000
+											}
+										}
+									}
+									set_defacto_liege = event_target:owner_liege
+								}
+								any_demesne_title = {
+									limit = {
+										tier = BARON
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+									grant_title = ROOT
+								}
+								event_target:new_holder = {
+									save_event_target_as = text_target
+									character_event = { id = GR.22 } # Notify player going independent
+									any_liege = {
+										character_event = { id = GR.19 } # Notify independence
+									}
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal of higher tier than Baron with vassals, all their vassals in the capital area were reassigned to liege, and then the holder was set independent"
+						}
+						else_if = { # If the holder has land that connects to the liege's capital, set the baronies free under peasants
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal, and was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+character_event = { # Border Gore cleanser (Total)
+	id = GR.17
+
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	only_independent = yes
+	only_playable = yes
+
+	trigger = {
+		holy_order = no # Holy orders are intended to hold baronies all over the place
+		NOT = {
+			has_landed_title = k_papal_state # The Pope should also be able to hold baronies all over the place
+		}
+		has_game_rule = {
+			name = exclave_purge
+			value = total
+		}
+		capital_scope = {
+			any_disconnected_province = {
+				sub_realm = no
+				NOR = {
+					#de_jure_liege_or_above = ROOT
+					is_connected_to = {
+						sub_realm = no
+						target = realm_capital
+						#land_gap = yes
+						naval_distance = 1000
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+		if = { # AI characters at war will get this event later
+			limit = {
+				ai = yes
+				war = yes
+				player_heir = {
+					ai = yes
+				}
+			}
+			player_heir = {
+				set_character_flag = delayed_cleanse_ai
+			}
+			break = yes
+		}
+		else_if = { # Players who are at war during succession do not need the extra stress element of getting their realm cleansed
+			limit = {
+				war = yes
+				ai = no
+			}
+			break = yes
+		}
+		# Counties are set free first, to avoid releasing vassals of vassals we first loop through provinces held by Kings, then Dukes, and finally Counts
+		while = { # Eliminate County exclaves (Kings)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (Dukes)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (All others)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										#land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Set Peasant Leaders free in 'chunks'
+			count = 100
+			limit = {
+				any_realm_province = {
+					has_province_flag = peasant_cleansed
+				}
+			}
+			random_realm_province = {
+				limit = {
+					has_province_flag = peasant_cleansed
+				}
+				create_character = {
+					random_traits = yes
+					dynasty = culture
+					religion = THIS
+					culture = THIS
+					female = 5
+					age = 25
+					trait = peasant_leader
+				}
+				new_character = {
+					save_event_target_as = new_holder
+				}
+				county = {
+					usurp_title = { target = event_target:new_holder type = revolt }
+				}
+				event_target:new_holder = {
+					save_event_target_as = text_target
+					any_liege = {
+						character_event = { id = GR.20 } # Notify peasant independence
+					}
+				}
+				holder_scope = {
+					set_defacto_liege = event_target:new_holder
+				}
+				log = "[This.GetName] is being set independent under a peasant leader ([new_holder.GetBestName])"
+				if = { # Special case for Nomads
+					limit = {
+						event_target:new_holder = {
+							is_nomadic = yes
+						}
+						any_province_holding = {
+							OR = {
+								holding_type = city
+								holding_type = temple
+								holding_type = castle
+								holding_type = tribal
+							}
+						}
+					}
+					event_target:new_holder = {
+						set_government_type = tribal_government
+					}
+					if = {
+						limit = {
+							any_province_holding = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+						}
+						random_province_holding = {
+							limit = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+							destroy_settlement = THIS
+						}
+					}
+					log = "The holder is nomadic, but the county is unsuitable for nomadic life - reverting to tribalism"
+				}
+				any_connected_province = {
+					sub_realm = ROOT
+					limit = {
+						has_province_flag = peasant_cleansed
+					}
+					county = {
+						usurp_title = { target = event_target:new_holder type = revolt }
+						log = "The [This.GetName] County is being assigned to [new_holder.GetBestName] as it is directly connected to their capital of [new_holder.Capital.GetName]"
+					}
+				}
+				event_target:new_holder = {
+					wealth = 300
+					prestige = 300
+					piety = 200
+					any_realm_province = {
+						clr_province_flag = peasant_cleansed
+					}
+				}
+			}
+		}
+		while = { # Eliminate Barony exclaves
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = ROOT
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = ROOT
+					limit = {
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							#de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								#land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "Baronies in [This.GetName] considered for cleansing"
+
+					county = {
+						save_event_target_as = barony_origin_province
+					}
+
+					any_province_holding = {
+						limit = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+							NOR = {
+								holding_type = nomad
+								holding_type = family_palace
+							}
+						}
+						holder_scope = {
+							save_event_target_as = owner_independent
+							liege = {
+								save_event_target_as = owner_liege
+							}
+						}
+						log = "[This.GetName] is considered for cleansing"
+						if = { # If the holder is you, set the barony free under a peasant
+							limit = {
+								holder_scope = {
+									character = ROOT
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+						else_if = { # Characters that only hold this barony are set free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										demesne_size = 2
+										num_of_vassals = 1
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they only held one holding"
+						}
+						else_if = { # If the holder has no holdings that connect to the realm capital, set them free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										any_demesne_title = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												#land_gap = yes
+												naval_distance = 1000
+											}
+										}
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they held no land connected to the liege's realm"
+						}
+						else_if = { # If the holder is higher tier than baron, but doesn't hold ANY count titles, transfer all vassals/baronies in the capital area to their liege and set them independent
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									higher_tier_than = BARON
+									NOT = {
+										any_demesne_title = {
+											tier = COUNT
+										}
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+							holder_scope = {
+								any_vassal = {
+									limit = {
+										any_realm_province = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												#land_gap = yes
+												naval_distance = 1000
+											}
+										}
+									}
+									set_defacto_liege = event_target:owner_liege
+								}
+								any_demesne_title = {
+									limit = {
+										tier = BARON
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+									grant_title = ROOT
+								}
+								event_target:new_holder = {
+									save_event_target_as = text_target
+									character_event = { id = GR.22 } # Notify player going independent
+									any_liege = {
+										character_event = { id = GR.19 } # Notify independence
+									}
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal of higher tier than Baron with vassals, all their vassals in the capital area were reassigned to liege, and then the holder was set independent"
+						}
+						else_if = { # If the holder has land that connects to the liege's capital, set the baronies free under peasants
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											#land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal, and was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+character_event = { # Border Gore cleanser (Limited Naval)
+	id = GR.18
+
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	only_independent = yes
+	only_playable = yes
+
+	trigger = {
+		holy_order = no # Holy orders are intended to hold baronies all over the place
+		NOT = {
+			has_landed_title = k_papal_state # The Pope should also be able to hold baronies all over the place
+		}
+		has_game_rule = {
+			name = exclave_purge
+			value = limited_naval
+		}
+		capital_scope = {
+			any_disconnected_province = {
+				sub_realm = no
+				NOR = {
+					de_jure_liege_or_above = ROOT
+					is_connected_to = {
+						sub_realm = no
+						target = realm_capital
+						land_gap = yes
+						naval_distance = 1000
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+		if = { # AI characters at war will get this event later
+			limit = {
+				ai = yes
+				war = yes
+				player_heir = {
+					ai = yes
+				}
+			}
+			player_heir = {
+				set_character_flag = delayed_cleanse_ai
+			}
+			break = yes
+		}
+		else_if = { # Players who are at war during succession do not need the extra stress element of getting their realm cleansed
+			limit = {
+				war = yes
+				ai = no
+			}
+			break = yes
+		}
+		# Counties are set free first, to avoid releasing vassals of vassals we first loop through provinces held by Kings, then Dukes, and finally Counts
+		while = { # Eliminate County exclaves (Kings)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = KING
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (Dukes)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+								tier = DUKE
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Eliminate County exclaves (All others)
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = no
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = no
+					limit = {
+						county = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							has_province_flag = peasant_cleansed
+							is_connected_to = {
+								sub_realm = no
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "[This.GetName] considered for cleansing"
+					county = {
+						save_event_target_as = county_to_clear
+					}
+					holder_scope = {
+						save_event_target_as = owner_independent
+						liege = {
+							save_event_target_as = owner_liege
+						}
+					}
+					if = { # If there's a vassal with NO land in the capital region of the top liege, set them free
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								NOT = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										is_connected_to = {
+											sub_realm = no
+											target = realm_capital
+											land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed"
+						holder_scope = {
+							save_event_target_as = text_target
+							character_event = { id = GR.22 } # Notify player going independent
+							any_liege = {
+								character_event = { id = GR.19 } # Notify independence
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # If the county belongs to a vassal that holds land in the capital region of the top liege, set them free but leave all land that IS in the capital region of the top liege
+						limit = {
+							holder_scope = {
+								NOT = {
+									character = ROOT
+								}
+								capital_scope = {
+									is_connected_to = {
+										target = event_target:county_to_clear
+									}
+								}
+								any_realm_province = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = 1000
+									}
+								}
+							}
+						}
+						log = "[This.GetName] is being cleansed in the first else_if"
+						holder_scope = {
+							any_realm_province = { # Reassign counties not conencted to the capital
+								limit = {
+									county = {
+										holder_scope = {
+											OR = {
+												character = event_target:owner_independent
+												any_liege = {
+													character = event_target:owner_independent
+												}
+											}
+										}
+									}
+									is_connected_to = {
+										sub_realm = no
+										target = realm_capital
+										land_gap = yes
+										naval_distance = 1000
+									}
+								}
+								if = {
+									limit = {
+										holder_scope = {
+											character = event_target:owner_independent
+										}
+									}
+									county = {
+										grant_title = event_target:owner_liege
+										log = "[This.GetName] County is reassigned to liege"
+									}
+								}
+								else_if = {
+									limit = {
+										holder_scope = {
+											NOT = {
+												character = event_target:owner_independent
+											}
+										}
+									}
+									holder_scope = {
+										set_defacto_liege = event_target:owner_liege
+										log = "[This.GetBestName] set as vassal of liege"
+									}
+								}
+							}
+							if = { # If they hold baronies within the liege's realm that are not connected to the province being cleansed, reassign them to liege
+								limit = {
+									any_realm_province = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+								}
+								log = "The character holds loose baronies in the Liege's realm"
+								any_realm_province = {
+									limit = {
+										county = {
+											holder_scope = {
+												same_realm = ROOT
+												NOR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										NOT = {
+											is_connected_to = {
+												target = event_target:county_to_clear
+											}
+										}
+									}
+									any_province_holding = {
+										limit = {
+											holder_scope = {
+												OR = {
+													character = event_target:owner_independent
+													any_liege = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+										}
+										log = "[This.GetName] Barony is being handled"
+										if = {
+											limit = {
+												holder_scope = {
+													character = event_target:owner_independent
+												}
+											}
+											grant_title = event_target:owner_liege
+											log = "[This.GetName] Barony given to liege"
+										}
+										else_if = {
+											limit = {
+												holder_scope = {
+													NOT = {
+														character = event_target:owner_independent
+													}
+												}
+											}
+											set_defacto_liege = event_target:owner_liege
+											log = "[This.GetName] Barony set as vassal of liege"
+										}
+									}
+								}
+							}
+							event_target:owner_independent = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+							}
+							set_defacto_liege = event_target:owner_independent
+							log = "[This.GetBestName] set independent"
+						}
+					}
+					else_if = { # Last resort is to create a peasant leader to seize control of the land
+						limit = {
+							holder_scope = {
+								capital_scope = {
+									NOT = {
+										is_connected_to = {
+											target = event_target:county_to_clear
+										}
+									}
+								}
+							}
+						}
+						set_province_flag = peasant_cleansed # The actual assigning of titles happen in a later while loop
+					}
+				}
+			}
+		}
+		while = { # Set Peasant Leaders free in 'chunks'
+			count = 100
+			limit = {
+				any_realm_province = {
+					has_province_flag = peasant_cleansed
+				}
+			}
+			random_realm_province = {
+				limit = {
+					has_province_flag = peasant_cleansed
+				}
+				create_character = {
+					random_traits = yes
+					dynasty = culture
+					religion = THIS
+					culture = THIS
+					female = 5
+					age = 25
+					trait = peasant_leader
+				}
+				new_character = {
+					save_event_target_as = new_holder
+				}
+				county = {
+					usurp_title = { target = event_target:new_holder type = revolt }
+				}
+				event_target:new_holder = {
+					save_event_target_as = text_target
+					any_liege = {
+						character_event = { id = GR.20 } # Notify peasant independence
+					}
+				}
+				holder_scope = {
+					set_defacto_liege = event_target:new_holder
+				}
+				log = "[This.GetName] is being set independent under a peasant leader ([new_holder.GetBestName])"
+				if = { # Special case for Nomads
+					limit = {
+						event_target:new_holder = {
+							is_nomadic = yes
+						}
+						any_province_holding = {
+							OR = {
+								holding_type = city
+								holding_type = temple
+								holding_type = castle
+								holding_type = tribal
+							}
+						}
+					}
+					event_target:new_holder = {
+						set_government_type = tribal_government
+					}
+					if = {
+						limit = {
+							any_province_holding = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+						}
+						random_province_holding = {
+							limit = {
+								holding_type = tribal
+								is_capital = no
+								holder_scope = {
+									character = event_target:new_holder
+								}
+							}
+							destroy_settlement = THIS
+						}
+					}
+					log = "The holder is nomadic, but the county is unsuitable for nomadic life - reverting to tribalism"
+				}
+				any_connected_province = {
+					sub_realm = ROOT
+					limit = {
+						has_province_flag = peasant_cleansed
+					}
+					county = {
+						usurp_title = { target = event_target:new_holder type = revolt }
+						log = "The [This.GetName] County is being assigned to [new_holder.GetBestName] as it is directly connected to their capital of [new_holder.Capital.GetName]"
+					}
+				}
+				event_target:new_holder = {
+					wealth = 300
+					prestige = 300
+					piety = 200
+					any_realm_province = {
+						clr_province_flag = peasant_cleansed
+					}
+				}
+			}
+		}
+		while = { # Eliminate Barony exclaves
+			count = 100
+			limit = {
+				capital_scope = {
+					any_disconnected_province = {
+						sub_realm = ROOT
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+				}
+			}
+			capital_scope = {
+				random_disconnected_province = {
+					sub_realm = ROOT
+					limit = {
+						county = {
+							holder_scope = {
+								NOT = {
+									same_realm = ROOT
+								}
+							}
+						}
+						NOR = {
+							de_jure_liege_or_above = ROOT
+							is_connected_to = {
+								sub_realm = ROOT
+								target = realm_capital
+								land_gap = yes
+								naval_distance = 1000
+							}
+						}
+					}
+					log = "Baronies in [This.GetName] considered for cleansing"
+
+					county = {
+						save_event_target_as = barony_origin_province
+					}
+
+					any_province_holding = {
+						limit = {
+							holder_scope = {
+								same_realm = ROOT
+							}
+							NOR = {
+								holding_type = nomad
+								holding_type = family_palace
+							}
+						}
+						holder_scope = {
+							save_event_target_as = owner_independent
+							liege = {
+								save_event_target_as = owner_liege
+							}
+						}
+						log = "[This.GetName] is considered for cleansing"
+						if = { # If the holder is you, set the barony free under a peasant
+							limit = {
+								holder_scope = {
+									character = ROOT
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+						else_if = { # Characters that only hold this barony are set free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										demesne_size = 2
+										num_of_vassals = 1
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they only held one holding"
+						}
+						else_if = { # If the holder has no holdings that connect to the realm capital, set them free
+							limit = {
+								holder_scope = {
+									NOR = {
+										character = ROOT
+										any_demesne_title = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												land_gap = yes
+												naval_distance = 1000
+											}
+										}
+									}
+								}
+							}
+							holder_scope = {
+								save_event_target_as = text_target
+								character_event = { id = GR.22 } # Notify player going independent
+								any_liege = {
+									character_event = { id = GR.19 } # Notify independence
+								}
+								set_defacto_liege = THIS
+							}
+							log = "[This.GetName] was set independent as they held no land connected to the liege's realm"
+						}
+						else_if = { # If the holder is higher tier than baron, but doesn't hold ANY count titles, transfer all vassals/baronies in the capital area to their liege and set them independent
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									higher_tier_than = BARON
+									NOT = {
+										any_demesne_title = {
+											tier = COUNT
+										}
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+							holder_scope = {
+								any_vassal = {
+									limit = {
+										any_realm_province = {
+											is_connected_to = {
+												sub_realm = ROOT
+												target = realm_capital
+												land_gap = yes
+												naval_distance = 1000
+											}
+										}
+									}
+									set_defacto_liege = event_target:owner_liege
+								}
+								any_demesne_title = {
+									limit = {
+										tier = BARON
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											land_gap = yes
+											naval_distance = 1000
+										}
+									}
+									grant_title = ROOT
+								}
+								event_target:new_holder = {
+									save_event_target_as = text_target
+									character_event = { id = GR.22 } # Notify player going independent
+									any_liege = {
+										character_event = { id = GR.19 } # Notify independence
+									}
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal of higher tier than Baron with vassals, all their vassals in the capital area were reassigned to liege, and then the holder was set independent"
+						}
+						else_if = { # If the holder has land that connects to the liege's capital, set the baronies free under peasants
+							limit = {
+								holder_scope = {
+									NOT = {
+										character = ROOT
+									}
+									any_realm_province = {
+										is_connected_to = {
+											sub_realm = ROOT
+											target = realm_capital
+											land_gap = yes
+											naval_distance = 1000
+										}
+									}
+								}
+							}
+							create_character = {
+								random_traits = yes
+								dynasty = culture
+								religion = PREV
+								culture = PREV
+								female = 5
+								age = 25
+								trait = peasant_leader
+							}
+							new_character = {
+								save_event_target_as = new_holder
+							}
+							usurp_title = { target = event_target:new_holder type = revolt }
+							save_event_target_as = text_target_barony
+							holder_scope = {
+								save_event_target_as = text_target
+								any_liege = {
+									character_event = { id = GR.21 } # Notify independence
+								}
+								set_defacto_liege = event_target:new_holder
+							}
+							log = "[This.GetName] belonged to a vassal, and was cleansed by giving it to a peasant leader ([new_holder.GetBestName])"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+character_event = { # Liege notified of vassal independence
+	id = GR.19
+	desc = EVTDESC_GR_19
+	picture = GFX_evt_large_army
+
+	ai = no
+
+	notification = yes
+
+	is_triggered_only = yes
+
+	portrait = event_target:text_target
+
+	option = {
+		name = OK
+	}
+}
+
+character_event = { # Liege notified of takeover by peasants
+	id = GR.20
+	desc = EVTDESC_GR_20
+	picture = GFX_evt_large_army
+
+	ai = no
+
+	notification = yes
+
+	is_triggered_only = yes
+
+	portrait = event_target:text_target
+
+	option = {
+		name = OK
+	}
+}
+
+character_event = { # Liege notified of barony takeover by peasants
+	id = GR.21
+	desc = EVTDESC_GR_21
+	picture = GFX_evt_large_army
+
+	ai = no
+
+	notification = yes
+
+	is_triggered_only = yes
+
+	portrait = event_target:text_target
+
+	option = {
+		name = OK
+	}
+}
+
+character_event = { # Character going independent
+	id = GR.22
+	desc = EVTDESC_GR_22
+	picture = GFX_evt_large_army
+
+	ai = no
+
+	notification = yes
+
+	is_triggered_only = yes
+
+	option = {
+		name = OK
+	}
+}
+
+character_event = { # Delayed cleansing
+	id = GR.23
+
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	ai = yes
+	only_playable = yes
+	war = no
+	has_character_flag = delayed_cleanse_ai
+
+	immediate = {
+		if = {
+			limit = {
+				independent = no
+			}
+			clr_character_flag = delayed_cleanse_ai
+		}
+		else_if = {
+			limit = {
+				has_game_rule = {
+					name = exclave_purge
+					value = limited
+				}
+			}
+			clr_character_flag = delayed_cleanse_ai
+			character_event = { id = GR.14 }
+		}
+		else_if = {
+			limit = {
+				has_game_rule = {
+					name = exclave_purge
+					value = significant
+				}
+			}
+			clr_character_flag = delayed_cleanse_ai
+			character_event = { id = GR.15 }
+		}
+		else_if = {
+			limit = {
+				has_game_rule = {
+					name = exclave_purge
+					value = harsh
+				}
+			}
+			clr_character_flag = delayed_cleanse_ai
+			character_event = { id = GR.16 }
+		}
+		else_if = {
+			limit = {
+				has_game_rule = {
+					name = exclave_purge
+					value = total
+				}
+			}
+			clr_character_flag = delayed_cleanse_ai
+			character_event = { id = GR.17 }
+		}
+		else_if = {
+			limit = {
+				has_game_rule = {
+					name = exclave_purge
+					value = limited_naval
+				}
+			}
+			clr_character_flag = delayed_cleanse_ai
+			character_event = { id = GR.18 }
+		}
+	}
+}
+
+character_event = { # Generate 'Fake Family' for characters without any
+	id = GR.30
+
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	only_playable = yes
+	min_age = 16
+	only_men = yes
+
+	trigger = {
+		OR = {
+			AND = {
+				ai = yes
+				has_game_rule = {
+					name = generate_families
+					value = ai_only
+				}
+			}
+			has_game_rule = {
+				name = generate_families
+				value = on
+			}
+		}
+		is_save_game = no
+		OR = {
+			is_married = no
+			AND = {
+				is_married = yes
+				num_of_children < 1
+				spouse = {
+					is_lowborn = yes
+				}
+			}
+		}
+		mercenary = no
+		holy_order = no
+		is_landed = yes
+		OR = {
+			is_feudal = yes
+			is_nomadic = yes
+			is_tribal = yes
+		}
+		NOR = {
+			government = confucian_bureaucracy
+			government = order_government
+			trait = eunuch
+			trait = celibate
+			has_nickname = nick_the_chaste
+		}
+		OR = {
+			NOT = { num_of_dynasty_members = 2 }
+			#NOT = {
+			#	any_dynasty_member = {
+			#		NOR = {
+			#			character = ROOT
+			#			is_child_of = ROOT
+			#		}
+			#		is_alive = yes
+			#	}
+			# }
+			NOT = {
+				any_close_relative = {
+					NOR = {
+						character = ROOT
+						is_child_of = ROOT
+					}
+					is_alive = yes
+				}
+			}
+			AND = {
+				num_of_children >= 1
+				NOT = {
+					any_child = {
+						mother = { always = yes }
+					}
+				}
+				NOT = {
+					any_dynasty_member = {
+						NOT = {
+							ROOT = {
+								is_father = PREV
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+
+		# Generate a fitting spouse, first and foremost
+		# Rulers with really old children might still end up with no mother, but that should be rare
+		if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 44
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 44
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 40
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 40
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 35
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 35
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 30
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 30
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 27
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 27
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 25
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 25
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 20
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 20
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+				age >= 18
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 18
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+		else_if = {
+			limit = {
+				is_married = no
+				can_marry = yes
+			}
+			set_character_flag = recieved_royal_marriage_aid_duty
+			create_character = {
+				age = 16
+				female = yes
+				religion = ROOT
+				culture = ROOT
+				dynasty = actually_culture
+				random_traits = yes
+			}
+			new_character = {
+				add_spouse = ROOT
+				save_event_target_as = mother_target
+			}
+			trigger_switch = {
+				on_trigger = tier
+				EMPEROR = { prestige = 400 }
+				KING = { prestige = 300 }
+				DUKE = { prestige = 200 }
+				COUNT = { prestige = 100 }
+			}
+		}
+
+		# Then, generate a sort of random amount of children
+		if = {
+			limit = {
+				num_of_children < 1
+				age >= 40
+			}
+
+			random_list = {
+				5 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 23
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 23
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 23
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 22
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 23
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 22
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 23
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 22
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 21
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 24
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 23
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 22
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 21
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				num_of_children < 1
+				age >= 30
+			}
+			random_list = {
+				5 = {
+					create_character = {
+						age = 13
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 13
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 13
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 12
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 13
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 12
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				5 = {
+					create_character = {
+						age = 13
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 12
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 11
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				5 = {
+					create_character = {
+						age = 13
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 12
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 11
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				num_of_children < 1
+				age >= 25
+			}
+			random_list = {
+				5 = {
+					create_character = {
+						age = 8
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 8
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 8
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 7
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				10 = {
+					create_character = {
+						age = 8
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 7
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				5 = {
+					create_character = {
+						age = 8
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 7
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 6
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				5 = {
+					create_character = {
+						age = 8
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 7
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 6
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				num_of_children < 1
+				age >= 20
+			}
+			random_list = {
+				15 = {
+					create_character = {
+						age = 1
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				5 = {
+					create_character = {
+						age = 1
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 1
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 1
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				num_of_children < 1
+				age >= 18
+			}
+			random_list = {
+				15 = {
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				5 = {
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 1
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 1
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				num_of_children < 1
+			}
+			random_list = {
+				18 = {
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = no
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+				2 = {
+					create_character = {
+						age = 0
+						religion = ROOT
+						culture = ROOT
+						female = yes
+					}
+					new_character = {
+						dynasty = ROOT
+						set_father = ROOT
+						set_mother = event_target:mother_target
+					}
+				}
+			}
+		}
+
+		# Set orphaned historical children to new mother
+		any_child = {
+			limit = {
+				NOR = {
+					mother = { always = no }
+					trait = legit_bastard
+					trait = bastard
+				}
+				ROOT = {
+					spouse = {
+						could_be_parent_of = PREVPREV
+					}
+				}
+			}
+			ROOT = {
+				spouse = {
+					save_event_target_as = new_mother
+				}
+			}
+			set_mother = event_target:new_mother
+		}
+
+		if = { # Caste fix
+			limit = {
+				religion = hindu
+				trait = kshatriya
+			}
+			any_child = {
+				limit = {
+					religion = hindu
+					NOT = { trait = kshatriya }
+				}
+				add_trait = kshatriya
+			}
+		}
+
+		any_child = {
+			character_event = { id = RoI.30121 } # Set religious branch to liege's branch
+		}
+
+		any_child = { # Fix for children not getting any traits
+			limit = {
+				age = 16
+				NOR = {
+					has_education_diplomacy_trigger = yes
+					has_education_martial_trigger = yes
+					has_education_learning_trigger = yes
+					has_education_stewardship_trigger = yes
+				}
+			}
+			add_random_education_trait = yes
+			random_independent_ruler = {
+				limit = {
+					PREV = {
+						can_copy_personality_trait_from = PREV
+					}
+				}
+				PREV = {
+					copy_random_personality_trait = PREV
+				}
+			}
+			random_independent_ruler = {
+				limit = {
+					PREV = {
+						can_copy_personality_trait_from = PREV
+					}
+				}
+				PREV = {
+					copy_random_personality_trait = PREV
+				}
+			}
+			random_independent_ruler = {
+				limit = {
+					PREV = {
+						can_copy_personality_trait_from = PREV
+					}
+				}
+				PREV = {
+					copy_random_personality_trait = PREV
+				}
+			}
+		}
+
+		any_child = {
+			limit = {
+				age = 10
+				NOT = { age = 16 }
+				NOT = { personality_traits = 2 }
+			}
+			random_independent_ruler = {
+				limit = {
+					PREV = {
+						can_copy_personality_trait_from = PREV
+					}
+				}
+				PREV = {
+					copy_random_personality_trait = PREV
+				}
+			}
+			random_independent_ruler = {
+				limit = {
+					PREV = {
+						can_copy_personality_trait_from = PREV
+					}
+				}
+				PREV = {
+					copy_random_personality_trait = PREV
+				}
+			}
+		}
+
+		any_child = {
+			limit = {
+				age = 6
+				NOT = { age = 10 }
+				NOT = { personality_traits = 1 }
+			}
+			random_independent_ruler = {
+				limit = {
+					PREV = {
+						can_copy_personality_trait_from = PREV
+					}
+				}
+				PREV = {
+					copy_random_personality_trait = PREV
+				}
+			}
+		}
+		recalc_succession = yes
+	}
+}


### PR DESCRIPTION
Basically instead of creating a delayed (potentially expensive) event, now the vanilla event is edited to account for baby portraits.
Not sure whether the second part, the catch-all-hardcoded-character-generations part (via on_host_change) actually works, as very likely no babies are affected by it: Babies generated after the initial startup events are always born naturally afaik.
So nothing is broken here, but further testing required if on_host_change is to be used for other things in the future.

May Time Baby deliver us from making mistakes in the future. Globnar.