### PR TITLE
Governments correction

### DIFF
--- a/CK2Plus/common/governments/feudal_governments.txt
+++ b/CK2Plus/common/governments/feudal_governments.txt
@@ -297,25 +297,23 @@ feudal_governments = {
 		frame_suffix = "_romanimperial"
 		potential = {
 			is_patrician = no
-			trigger_if = {
-				limit = {
+			OR = {
+				AND = {
 					is_save_game = no
 					has_game_started = no
-				}
-				realm = {
-					OR = {
-						title = e_byzantium
-						title = e_roman_empire
+					realm = {
+						OR = {
+							title = e_byzantium
+							title = e_roman_empire
+						}
 					}
 				}
-			}
-			trigger_else = {
 				realm = {
-					OR = {
-						title = e_byzantium
-						title = e_roman_empire
-					}
 					has_law = succ_byzantine_elective
+					OR = {
+						title = e_byzantium
+						title = e_roman_empire
+					}
 				}
 			}
 			NOR = {

--- a/CK2Plus/common/governments/republic_governments.txt
+++ b/CK2Plus/common/governments/republic_governments.txt
@@ -35,7 +35,7 @@ republic_governments = {
 							NOT = {
 								liege_before_war = {
 									is_merchant_republic = yes
-									NOT = { character = PREV
+									NOT = { character = PREV }
 								}
 							}
 						}
@@ -64,7 +64,7 @@ republic_governments = {
 							is_merchant_republic = yes
 						}
 					}
-				}	
+				}
 			}
 			NOR = {
 				is_government_potential = confucian_bureaucracy

--- a/CK2Plus/common/governments/republic_governments.txt
+++ b/CK2Plus/common/governments/republic_governments.txt
@@ -22,51 +22,49 @@ republic_governments = {
 		frame_suffix = "_merchantrepublic"
 		title_prefix = "city_"
 		potential = {
-			trigger_if = {
-				limit = { has_game_started = yes }
-				OR = {
-					AND = {
+			OR = {
+				AND = {
+					has_game_started = no
+					OR = {
 						is_patrician = yes
-						liege_before_war = {
-							is_merchant_republic = yes
-							NOR = {
-								character = PREV
+						AND = {
+							capital_scope = { port = yes }
+							capital_holding = { holding_type = CITY }
+							higher_real_tier_than = COUNT
+							any_demesne_province = { always = yes }
+							NOT = {
 								liege_before_war = {
-									NOT = { character = PREV }
 									is_merchant_republic = yes
+									NOT = { character = PREV
 								}
 							}
 						}
 					}
-					AND = {
-						is_merchant_republic = yes
-						higher_real_tier_than = count
-						any_demesne_province = { always = yes }
-						NOT = {
-							liege_before_war = {
-								NOT = { character = PREV }
-								is_merchant_republic = yes
-							}
-						}
-					}
 				}
-			}
-			trigger_else = {
-				OR = {
+				AND = {
 					is_patrician = yes
-					AND = {
-						capital_scope = { port = yes }
-						capital_holding = { holding_type = CITY }
-						higher_real_tier_than = count
-						any_demesne_province = { always = yes }
-						NOT = {
+					liege_before_war = {
+						is_merchant_republic = yes
+						NOR = {
+							character = PREV
 							liege_before_war = {
-								is_merchant_republic = yes
 								NOT = { character = PREV }
+								is_merchant_republic = yes
 							}
 						}
 					}
 				}
+				AND = {
+					is_merchant_republic = yes
+					higher_real_tier_than = COUNT
+					any_demesne_province = { always = yes }
+					NOT = {
+						liege_before_war = {
+							NOT = { character = PREV }
+							is_merchant_republic = yes
+						}
+					}
+				}	
 			}
 			NOR = {
 				is_government_potential = confucian_bureaucracy
@@ -119,18 +117,13 @@ republic_governments = {
 		frame_suffix = "_republic"
 		title_prefix = "city_"
 		potential = {
-			trigger_if = {
-				limit = { ai = yes}
-				NOR = {
-					is_government_potential = confucian_bureaucracy
-					is_government_potential = merchant_republic_government
-					is_government_potential = mercenary_government
-					is_government_potential = order_government
-					is_government_potential = theocracy_government
-				}
-			}
-			trigger_else = {
-				always = no
+			ai = yes
+			NOR = {
+				is_government_potential = confucian_bureaucracy
+				is_government_potential = merchant_republic_government
+				is_government_potential = mercenary_government
+				is_government_potential = order_government
+				is_government_potential = theocracy_government
 			}
 		}
 

--- a/CK2Plus/common/governments/theocracy_governments.txt
+++ b/CK2Plus/common/governments/theocracy_governments.txt
@@ -25,28 +25,21 @@ theocracy_governments = {
 		frame_suffix = "_theocracy"
 		title_prefix = "temple_"
 		potential = {
-			trigger_if = {
-				limit = { ai = yes }
-				OR = {
-					controls_religion = yes
-					capital_holding = {
-						holding_type = TEMPLE
-					}
-				}
-				NOR = {
-					has_religion_feature = religion_temporal_head
-					is_government_potential = muslim_government
-					is_government_potential = theocratic_feudal_government
-					is_government_potential = order_government
-					is_government_potential = mercenary_government # CK2Plus
-					AND = {
-						religion = norse_pagan_reformed
-						has_religion_features = no
-					}
-				}
+			ai = yes
+			OR = {
+				controls_religion = yes
+				capital_holding = { holding_type = TEMPLE }
 			}
-			trigger_else = {
-				always = no
+			NOR = {
+				has_religion_feature = religion_temporal_head
+				is_government_potential = muslim_government
+				is_government_potential = theocratic_feudal_government
+				is_government_potential = order_government
+				is_government_potential = mercenary_government # CK2Plus
+				AND = {
+					religion = norse_pagan_reformed
+					has_religion_features = no
+				}
 			}
 		}
 


### PR DESCRIPTION
Please test this before merging it. It should work but I was not at my computer when I wrote it so I could not. This removes `trigger_if` checks from the government potentials because the game doesn't read them correctly.