### PR TITLE
Tweak: Disable Monarch's Journey in main menu, again

### DIFF
--- a/CK2Plus/interface/highlighted_ruler.gui
+++ b/CK2Plus/interface/highlighted_ruler.gui
@@ -1,0 +1,1 @@
+# cleared out to keep this from popping back up every two weeks


### PR DESCRIPTION
Popped back up again with a new highlighted ruler, this disables it permanently