### PR TITLE
History/aragonese fixes

### DIFF
--- a/CK2Plus/history/characters/castillan.txt
+++ b/CK2Plus/history/characters/castillan.txt
@@ -2328,6 +2328,11 @@
 	1136.7.29 = {
 		birth = yes
 	}
+	1138.1.1 = {
+		effect = {
+			add_betrothal = 210506
+		}
+	}
 	1174.10.16 = {
 		death = yes
 	}

--- a/CK2Plus/history/characters/castillan.txt
+++ b/CK2Plus/history/characters/castillan.txt
@@ -2307,7 +2307,7 @@
 }
 
 210507 = {
-	name = "Petronila" #AKA: Petronila I
+	name = "Peyronela" #AKA: Peyronela I
 	female = yes
 	dynasty = 442
 	martial = 6

--- a/CK2Plus/history/titles/c_bearn.txt
+++ b/CK2Plus/history/titles/c_bearn.txt
@@ -99,6 +99,10 @@
 	holder = 205540 #Gaston VI de béarn
 }
 
+1187.1.1 = {
+	liege = k_aragon # Alfonso II of Aragon
+}
+
 1214.1.1 = {
 	holder = 205543 #Guillem Ramon I de Béarn
 }

--- a/CK2Plus/history/titles/k_aragon.txt
+++ b/CK2Plus/history/titles/k_aragon.txt
@@ -18,8 +18,8 @@
 1134.9.7={
 	holder=70233 # Ramiro II Jimena
 }
-1157.8.16={
-	holder=210507 # Petronila Ramírez Jimena
+1137.8.16={ # Abdication of Ramiro II
+	holder=210507 # Peyronela Ramírez Jimena
 }
 1164.1.1={
 	holder=210500 # Alfons II d'Aragó


### PR DESCRIPTION
These are just some minor issues I noticed with a couple things.

First, Petronilla (Aragonese: Peyronela) was queen of Aragon from 1137 (when her father abdicated) - 1164 (when she abdicated). I also changed her name to the Aragonese version, since I think that makes more sense given she is Aragonese, not Castillan.

Second, Bearn was a vassal of [Alfonso II](https://en.wikipedia.org/wiki/Alfonso_II_of_Aragon) of Aragon (and Aragon generally) from 1187 until 1228, when [Guillem II](https://en.wikipedia.org/wiki/Guillem_II_de_Montcada) switched allegiances to England.